### PR TITLE
Add cancelAutoOrderItemByReferenceOrderId samples across all languages

### DIFF
--- a/SDK_PUBLISHING_ISSUES.md
+++ b/SDK_PUBLISHING_ISSUES.md
@@ -1,0 +1,47 @@
+# SDK Publishing Issues — Java & C# behind on 4.1.74
+
+Hey Perry — while bumping `sdk_samples` to SDK **4.1.74** to write samples for the new `cancelAutoOrderItemByReferenceOrderId` method, I found that two language SDKs haven't been published up to that version. The other five are fine.
+
+## Status across languages
+
+| Language   | Target  | Latest published | Status   |
+|------------|---------|------------------|----------|
+| Ruby       | 4.1.74  | 4.1.74           | OK       |
+| JavaScript | 4.1.74  | 4.1.74           | OK       |
+| TypeScript | 4.1.74  | 4.1.74           | OK       |
+| PHP        | 4.1.74  | 4.1.74           | OK       |
+| Python     | 4.1.74  | 4.1.74           | OK       |
+| **Java**   | 4.1.74  | **4.1.13**       | **Behind** |
+| **C#**     | 4.1.74  | **4.1.66**       | **Behind** |
+
+## Java — `com.ultracart:rest-sdk` on Maven Central
+
+- Highest published version: **4.1.13** (timestamped 2025‑05‑20)
+- Source: `https://search.maven.org/solrsearch/select?q=g:com.ultracart+AND+a:rest-sdk&core=gav&rows=20&wt=json`
+- Error seen locally:
+  ```
+  [ERROR] Could not find artifact com.ultracart:rest-sdk:jar:4.1.74 in central
+  ```
+- Gap: **61 versions behind** (4.1.14 … 4.1.74)
+
+Looks like Java publishing may have broken around 4.1.13 in May 2025.
+
+## C# — `com.ultracart.admin.v2` on NuGet.org
+
+- Highest published version: **4.1.66**
+- Source: `https://api.nuget.org/v3-flatcontainer/com.ultracart.admin.v2/index.json`
+- Error seen locally:
+  ```
+  Unable to find version '4.1.74' of package 'com.ultracart.admin.v2'.
+  Package 'com.ultracart.admin.v2.4.1.74' is not found on source 'https://api.nuget.org/v3/index.json'.
+  ```
+- Gap: **8 versions behind** (4.1.67 … 4.1.74)
+
+C# is much closer — likely just a few missed publishes rather than a broken pipeline.
+
+## What I need
+
+1. **Java**: republish `com.ultracart:rest-sdk` up through 4.1.74 on Maven Central (or confirm which version is the real "latest" if the pipeline needs fixing first).
+2. **C#**: publish 4.1.67 → 4.1.74 of `com.ultracart.admin.v2` on NuGet.org.
+
+Once published, I'll re‑run `mvn package` / `nuget restore` on my side and finish the Java and C# samples for `cancelAutoOrderItemByReferenceOrderId`. In the meantime I'm moving ahead with the other five languages.

--- a/csharp/SDKSample.csproj
+++ b/csharp/SDKSample.csproj
@@ -614,8 +614,8 @@
     <Compile Include="workflow\UpdateWorkflowTask.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="com.ultracart.admin.v2, Version=4.1.15.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\com.ultracart.admin.v2.4.1.15\lib\net48\com.ultracart.admin.v2.dll</HintPath>
+    <Reference Include="com.ultracart.admin.v2, Version=4.1.74.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\com.ultracart.admin.v2.4.1.74\lib\net48\com.ultracart.admin.v2.dll</HintPath>
     </Reference>
     <Reference Include="JsonSubTypes, Version=1.7.0.0, Culture=neutral, PublicKeyToken=ee75fc290dbc1176">
       <HintPath>packages\JsonSubTypes.1.7.0\lib\net40\JsonSubTypes.dll</HintPath>

--- a/csharp/auto_order/CancelAutoOrderItemByReferenceOrderId.cs
+++ b/csharp/auto_order/CancelAutoOrderItemByReferenceOrderId.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Reflection;
+using com.ultracart.admin.v2.Api;
+using com.ultracart.admin.v2.Model;
+
+// NOTE: requires com.ultracart.admin.v2 version that ships CancelAutoOrderItemByReferenceOrderId.
+// At the time this sample was written NuGet only had 4.1.66 — a newer publish is required.
+namespace SdkSample.auto_order
+{
+    public class CancelAutoOrderItemByReferenceOrderId
+    {
+        /*
+         * Cancel a single item on an auto order, identified by the reference (original) order id
+         * that placed the auto order and the original item id on that order. This is useful when
+         * you know the original UltraCart order id rather than the auto_order_oid.
+         */
+        public static void Execute()
+        {
+            Console.WriteLine("--- " + MethodBase.GetCurrentMethod()?.DeclaringType?.Name + " ---");
+
+            try
+            {
+                AutoOrderApi autoOrderApi = new AutoOrderApi(Constants.ApiKey);
+
+                string referenceOrderId = "DEMO-12345678"; // the UltraCart order id that placed the auto order
+                string originalItemId   = "ITEM001";       // the merchant item id on that original order
+                string expand           = "items";         // see https://www.ultracart.com/api/#resource_auto_order.html for list
+
+                AutoOrderResponse response = autoOrderApi.CancelAutoOrderItemByReferenceOrderId(
+                    referenceOrderId,
+                    originalItemId,
+                    expand
+                );
+                AutoOrder autoOrder = response.AutoOrder;
+                Console.WriteLine(autoOrder);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Console.WriteLine(ex.StackTrace);
+            }
+        }
+    }
+}

--- a/csharp/packages.config
+++ b/csharp/packages.config
@@ -16,5 +16,5 @@
   <package id="System.Text.Json" version="9.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
-  <package id="com.ultracart.admin.v2" version="4.1.15" targetFramework="net48" />
+  <package id="com.ultracart.admin.v2" version="4.1.74" targetFramework="net48" />
 </packages>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.ultracart</groupId>
             <artifactId>rest-sdk</artifactId>
-            <version>4.1.15</version>
+            <version>4.1.74</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/java/src/auto_order/CancelAutoOrderItemByReferenceOrderId.java
+++ b/java/src/auto_order/CancelAutoOrderItemByReferenceOrderId.java
@@ -1,0 +1,36 @@
+package auto_order;
+
+import com.ultracart.admin.v2.AutoOrderApi;
+import com.ultracart.admin.v2.models.*;
+import com.ultracart.admin.v2.util.ApiException;
+
+// NOTE: requires rest-sdk version that ships cancelAutoOrderItemByReferenceOrderId.
+// At the time this sample was written Maven Central only had 4.1.13 — a newer publish is required.
+public class CancelAutoOrderItemByReferenceOrderId {
+    /*
+     * Cancel a single item on an auto order, identified by the reference (original) order id
+     * that placed the auto order and the original item id on that order. This is useful when
+     * you know the original UltraCart order id rather than the auto_order_oid.
+     */
+    public static void execute() {
+        AutoOrderApi autoOrderApi = new AutoOrderApi(common.Constants.API_KEY);
+
+        String referenceOrderId = "DEMO-12345678"; // the UltraCart order id that placed the auto order
+        String originalItemId   = "ITEM001";       // the merchant item id on that original order
+        String expand           = "items";         // see https://www.ultracart.com/api/#resource_auto_order.html for list
+
+        try {
+            AutoOrderResponse response = autoOrderApi.cancelAutoOrderItemByReferenceOrderId(
+                referenceOrderId,
+                originalItemId,
+                expand,
+                null
+            );
+            AutoOrder autoOrder = response.getAutoOrder();
+            System.out.println(autoOrder);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AutoOrderApi#cancelAutoOrderItemByReferenceOrderId");
+            e.printStackTrace();
+        }
+    }
+}

--- a/javascript/auto_order/cancelAutoOrderItemByReferenceOrderId.js
+++ b/javascript/auto_order/cancelAutoOrderItemByReferenceOrderId.js
@@ -1,0 +1,27 @@
+import { autoOrderApi } from '../api.js';
+
+/**
+ * Cancel a single item on an auto order, identified by the reference (original) order id
+ * that placed the auto order and the original item id on that order. This is useful when
+ * you know the original UltraCart order id rather than the auto_order_oid.
+ */
+export async function execute() {
+  const referenceOrderId = "DEMO-12345678"; // the UltraCart order id that placed the auto order
+  const originalItemId   = "ITEM001";       // the merchant item id on that original order
+  const opts = {
+    '_expand': 'items' // see https://www.ultracart.com/api/#resource_auto_order.html for list
+  };
+
+  const response = await new Promise((resolve, reject) => {
+    autoOrderApi.cancelAutoOrderItemByReferenceOrderId(referenceOrderId, originalItemId, opts, function (error, data, response) {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(data, response);
+      }
+    });
+  });
+
+  const autoOrder = response.auto_order;
+  console.log(autoOrder);
+}

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "luxon": "3.2.1",
         "ssl-root-cas": "^1.2.3",
-        "ultra_cart_rest_api_v2": "^4.1.15"
+        "ultra_cart_rest_api_v2": "^4.1.74"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1252,9 +1252,10 @@
       }
     },
     "node_modules/ultra_cart_rest_api_v2": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.15.tgz",
-      "integrity": "sha512-BAIqUydsQ+V2OQXu6+BphCF663HtIYbMeub/yP7HGgUu2e5wXoorHdK3hSRq7K1YtZ6aVUFwyunN8ICVPGr5Kg==",
+      "version": "4.1.74",
+      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.74.tgz",
+      "integrity": "sha512-koIJwR0JpKrJKyIePDBkMMAd0pt5/mERdi/7otmyc8n1+3XtQjKkagHzZImjBxZStdJDRrwgv1gPzgKGXDn7Uw==",
+      "license": "Unlicense",
       "dependencies": {
         "@babel/cli": "^7.0.0",
         "superagent": "^5.3.0"
@@ -2201,9 +2202,9 @@
       }
     },
     "ultra_cart_rest_api_v2": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.15.tgz",
-      "integrity": "sha512-BAIqUydsQ+V2OQXu6+BphCF663HtIYbMeub/yP7HGgUu2e5wXoorHdK3hSRq7K1YtZ6aVUFwyunN8ICVPGr5Kg==",
+      "version": "4.1.74",
+      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.74.tgz",
+      "integrity": "sha512-koIJwR0JpKrJKyIePDBkMMAd0pt5/mERdi/7otmyc8n1+3XtQjKkagHzZImjBxZStdJDRrwgv1gPzgKGXDn7Uw==",
       "requires": {
         "@babel/cli": "^7.0.0",
         "superagent": "^5.3.0"

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "luxon": "3.2.1",
     "ssl-root-cas": "^1.2.3",
-    "ultra_cart_rest_api_v2": "^4.1.15"
+    "ultra_cart_rest_api_v2": "^4.1.74"
   }
 }

--- a/php/auto_order/cancelAutoOrderItemByReferenceOrderId.php
+++ b/php/auto_order/cancelAutoOrderItemByReferenceOrderId.php
@@ -1,0 +1,26 @@
+<?php
+
+ini_set('display_errors', 1);
+
+/*
+ * Cancel a single item on an auto order, identified by the reference (original) order id
+ * that placed the auto order and the original item id on that order. This is useful when
+ * you know the original UltraCart order id rather than the auto_order_oid.
+ */
+
+require_once '../vendor/autoload.php';
+require_once '../samples.php';
+
+$auto_order_api = Samples::getAutoOrderApi();
+
+$reference_order_id = "DEMO-12345678"; // the UltraCart order id that placed the auto order
+$original_item_id   = "ITEM001";       // the merchant item id on that original order
+$_expand            = "items";         // see https://www.ultracart.com/api/#resource_auto_order.html for list
+
+$response = $auto_order_api->cancelAutoOrderItemByReferenceOrderId(
+    $reference_order_id,
+    $original_item_id,
+    $_expand
+);
+$auto_order = $response->getAutoOrder();
+var_dump($auto_order);

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "ultracart/rest_api_v2_sdk_php": "4.1.15"
+    "ultracart/rest_api_v2_sdk_php": "4.1.74"
   },
   "config": {
     "discard-changes" : true

--- a/python/auto_order/cancel_auto_order_item_by_reference_order_id.py
+++ b/python/auto_order/cancel_auto_order_item_by_reference_order_id.py
@@ -1,0 +1,20 @@
+# Cancel a single item on an auto order, identified by the reference (original) order id
+# that placed the auto order and the original item id on that order. This is useful when
+# you know the original UltraCart order id rather than the auto_order_oid.
+
+from ultracart.apis import AutoOrderApi
+from samples import api_client
+
+auto_order_api = AutoOrderApi(api_client())
+
+reference_order_id = "DEMO-12345678"  # the UltraCart order id that placed the auto order
+original_item_id   = "ITEM001"        # the merchant item id on that original order
+expand             = "items"          # see https://www.ultracart.com/api/#resource_auto_order.html for list
+
+response = auto_order_api.cancel_auto_order_item_by_reference_order_id(
+    reference_order_id,
+    original_item_id,
+    expand=expand
+)
+auto_order = response.auto_order
+print(auto_order)

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'rubocop', group: 'development'
-gem 'ultracart_api', '4.1.15'
+gem 'ultracart_api', '4.1.74'

--- a/ruby/auto_order/cancel_auto_order_item_by_reference_order_id.rb
+++ b/ruby/auto_order/cancel_auto_order_item_by_reference_order_id.rb
@@ -1,0 +1,20 @@
+# Cancel a single item on an auto order, identified by the reference (original) order id
+# that placed the auto order and the original item id on that order. This is useful when
+# you know the original UltraCart order id rather than the auto_order_oid.
+
+require_relative '../constants'
+require 'ultracart_api'
+
+auto_order_api = UltracartClient::AutoOrderApi.new_using_api_key(Constants::API_KEY)
+
+reference_order_id = "DEMO-12345678" # the UltraCart order id that placed the auto order
+original_item_id   = "ITEM001"       # the merchant item id on that original order
+expand             = "items"         # see https://www.ultracart.com/api/#resource_auto_order.html for list
+
+response = auto_order_api.cancel_auto_order_item_by_reference_order_id(
+  reference_order_id,
+  original_item_id,
+  { _expand: expand }
+)
+auto_order = response.auto_order
+puts auto_order.inspect

--- a/typescript/auto_order/CancelAutoOrderItemByReferenceOrderId.ts
+++ b/typescript/auto_order/CancelAutoOrderItemByReferenceOrderId.ts
@@ -1,0 +1,21 @@
+import { autoOrderApi } from '../api';
+
+/**
+ * Cancel a single item on an auto order, identified by the reference (original) order id
+ * that placed the auto order and the original item id on that order. This is useful when
+ * you know the original UltraCart order id rather than the auto_order_oid.
+ */
+export async function execute(): Promise<void> {
+  const referenceOrderId: string = "DEMO-12345678"; // the UltraCart order id that placed the auto order
+  const originalItemId: string   = "ITEM001";       // the merchant item id on that original order
+  const expand: string           = "items";         // see https://www.ultracart.com/api/#resource_auto_order.html for list
+
+  const response = await autoOrderApi.cancelAutoOrderItemByReferenceOrderId({
+    referenceOrderId: referenceOrderId,
+    originalItemId: originalItemId,
+    expand: expand
+  });
+
+  const autoOrder = response.auto_order;
+  console.log(autoOrder);
+}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -7,7 +7,7 @@
     "@types/node": "^16.18.126",
     "luxon": "2.5.2",
     "typescript": "^4.9.5",
-    "ultracart_rest_api_v2_typescript": "4.1.15",
+    "ultracart_rest_api_v2_typescript": "4.1.74",
     "uuid": "^11.1.0"
   },
   "author": "UltraCart",


### PR DESCRIPTION
## Summary
- Bumps every language's SDK pin to **4.1.74** (Ruby, JavaScript, TypeScript, PHP, Python, Java, C#)
- Adds one sample per language under each `<lang>/auto_order/` directory demonstrating the new `cancelAutoOrderItemByReferenceOrderId` method on `AutoOrderApi`
- Adds `SDK_PUBLISHING_ISSUES.md` documenting that the Java SDK is stuck at 4.1.13 on Maven Central and the C# SDK is stuck at 4.1.66 on NuGet — both need a new publish before their samples can build

## Notes
- The new method takes `reference_order_id` + `original_item_id` and cancels a single item on the matching auto order — useful when you know the original UltraCart order id but not the `auto_order_oid`.
- All 7 samples follow the conventions of the existing `pauseAutoOrder` sample in each language (helper-based client init, placeholder IDs, single API call, print response).
- Java and C# samples are authored against inferred signatures since the SDKs aren't published yet; each file carries a one-line comment calling that out.

## Test plan
- [x] Ruby: `ruby -c` — syntax OK
- [x] JavaScript: `node --check` — OK
- [x] TypeScript: `tsc --noEmit` against real 4.1.74 SDK types — OK (confirms method signature matches)
- [x] PHP: `php -l` — OK
- [x] Python: `py_compile` — OK
- [ ] Java: post-publish `mvn package` smoke test once rest-sdk 4.1.74 lands on Maven Central
- [ ] C#: post-publish `nuget restore` + MSBuild smoke test once com.ultracart.admin.v2 4.1.74 lands on NuGet
- [ ] No live API calls made — samples use placeholder IDs (`DEMO-12345678`, `ITEM001`) consistent with other samples in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)