### PR TITLE
Chargeback evidence sample (7 languages) + bump SDKs to 4.1.88

### DIFF
--- a/csharp/SDKSample.csproj
+++ b/csharp/SDKSample.csproj
@@ -614,8 +614,8 @@
     <Compile Include="workflow\UpdateWorkflowTask.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="com.ultracart.admin.v2, Version=4.1.15.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\com.ultracart.admin.v2.4.1.15\lib\net48\com.ultracart.admin.v2.dll</HintPath>
+    <Reference Include="com.ultracart.admin.v2, Version=4.1.88.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\com.ultracart.admin.v2.4.1.88\lib\net48\com.ultracart.admin.v2.dll</HintPath>
     </Reference>
     <Reference Include="JsonSubTypes, Version=1.7.0.0, Culture=neutral, PublicKeyToken=ee75fc290dbc1176">
       <HintPath>packages\JsonSubTypes.1.7.0\lib\net40\JsonSubTypes.dll</HintPath>

--- a/csharp/order/GetChargebackEvidence.cs
+++ b/csharp/order/GetChargebackEvidence.cs
@@ -1,0 +1,507 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using com.ultracart.admin.v2.Api;
+using com.ultracart.admin.v2.Model;
+
+namespace SdkSample.order
+{
+    /// <summary>
+    /// GetChargebackEvidence
+    ///
+    /// Pulls everything from UltraCart that is useful when fighting a chargeback
+    /// dispute and prints a formatted evidence report. Designed as a starting
+    /// point for building the actual evidence packet you submit to the card
+    /// processor.
+    ///
+    /// What this sample demonstrates:
+    ///   1. Order detail with the SPECIFIC expansions a chargeback case relies
+    ///      on. Notice we list every expansion explicitly - no shortcuts.
+    ///      Listing them individually keeps your payload small and forces you
+    ///      to think about what evidence each one represents.
+    ///   2. Email delivery records via the dedicated /emails endpoint (not via
+    ///      expansion). Use the dedicated endpoint for chargeback work - it is
+    ///      the canonical full-fidelity source for SES delivery events on every
+    ///      order.
+    ///   3. Page view history (the customer was on your site, navigated through
+    ///      pages, spent time before placing the order).
+    ///   4. Auto-order detection: a large fraction of chargebacks are
+    ///      subscription disputes. When the order is part of an auto order,
+    ///      the sample pulls the parent subscription, every rebill, and the
+    ///      auto-order-level email log. For rebills specifically, the page-view
+    ///      lookup pivots to the ORIGINAL order (the rebill itself has no
+    ///      checkout session).
+    ///
+    /// Requires the May 2026 SDK build with GetOrderEmails,
+    /// GetOrderPageViewHistory, and GetAutoOrderEmails.
+    /// </summary>
+    public class GetChargebackEvidence
+    {
+        private static readonly string OrderExpansion = string.Join(",", new[]
+        {
+            "billing",                  // address customer entered for billing
+            "shipping",                 // address goods shipped to
+            "payment",                  // payment method, card last four, gateway info
+            "payment.transaction",      // auth/capture/refund timeline
+            "summary",                  // totals, tax, shipping, weights
+            "items",                    // line items the customer ordered
+            "coupon",                   // discounts the customer chose to apply
+            "customer_profile",         // returning-customer signal, account history
+            "auto_order",               // detect subscription chargebacks
+            "utms",                     // entry-path UTM clicks (attribution chain)
+            "marketing",                // affiliate / source-code attribution
+            "gift",                     // gift-giving intent if applicable
+            "point_of_sale",            // POS terminal / location for retail orders
+            "channel_partner"           // channel partner data
+        });
+
+        private static readonly string AutoOrderExpansion = string.Join(",", new[]
+        {
+            "items",                    // subscription line items + frequency
+            "rebill_orders",            // every rebill that has occurred
+            "logs",                     // status changes, payment attempts, cancellations
+            "management"                // self-service management state
+        });
+
+        public static void Execute()
+        {
+            Execute("DEMO-0009104976");
+        }
+
+        public static void Execute(string orderId)
+        {
+            OrderApi orderApi = new OrderApi(Constants.ApiKey);
+            AutoOrderApi autoOrderApi = new AutoOrderApi(Constants.ApiKey);
+
+            // Order detail
+            OrderResponse orderResponse = orderApi.GetOrder(orderId, OrderExpansion);
+            if (orderResponse.Error != null) FailOp("GetOrder", orderResponse.Error);
+            Order order = orderResponse.Order;
+
+            // Use the dedicated /emails endpoint rather than _expand=emails. The
+            // dedicated endpoint is the canonical full-fidelity source for SES
+            // delivery events.
+            OrderEmailsResponse emailsResponse = orderApi.GetOrderEmails(orderId);
+            if (emailsResponse.Error != null) FailOp("GetOrderEmails", emailsResponse.Error);
+            List<OrderEmail> emails = emailsResponse.Emails ?? new List<OrderEmail>();
+
+            // Auto-order chain BEFORE page views: a rebill's own page view
+            // history is empty - the meaningful history lives on the original order.
+            AutoOrder autoOrder = null;
+            List<AutoOrderEmail> autoOrderEmails = new List<AutoOrderEmail>();
+            List<Order> rebillOrders = new List<Order>();
+            OrderAutoOrder autoOrderPointer = order.AutoOrder;
+            if (autoOrderPointer != null && autoOrderPointer.AutoOrderOid.HasValue)
+            {
+                int autoOrderOid = autoOrderPointer.AutoOrderOid.Value;
+
+                AutoOrderResponse aoResponse = autoOrderApi.GetAutoOrder(autoOrderOid, AutoOrderExpansion);
+                if (aoResponse.Error != null) FailOp("GetAutoOrder", aoResponse.Error);
+                autoOrder = aoResponse.AutoOrder;
+                rebillOrders = autoOrder.RebillOrders ?? new List<Order>();
+
+                AutoOrderEmailsResponse aoEmailsResponse = autoOrderApi.GetAutoOrderEmails(autoOrderOid);
+                if (aoEmailsResponse.Error != null) FailOp("GetAutoOrderEmails", aoEmailsResponse.Error);
+                autoOrderEmails = aoEmailsResponse.Emails ?? new List<AutoOrderEmail>();
+            }
+
+            // For a rebill chargeback, page views live on the ORIGINAL order.
+            string pageViewOrderId = orderId;
+            bool pageViewIsRedirected = false;
+            if (autoOrder != null
+                && !string.IsNullOrEmpty(autoOrder.OriginalOrderId)
+                && !autoOrder.OriginalOrderId.Equals(orderId, StringComparison.OrdinalIgnoreCase))
+            {
+                pageViewOrderId = autoOrder.OriginalOrderId;
+                pageViewIsRedirected = true;
+            }
+
+            OrderPageViewHistoryResponse pageViewResponse = orderApi.GetOrderPageViewHistory(pageViewOrderId);
+            if (pageViewResponse.Error != null) FailOp("GetOrderPageViewHistory", pageViewResponse.Error);
+            List<OrderPageView> pageViews = pageViewResponse.PageViews ?? new List<OrderPageView>();
+            string sessionReferrer = pageViewResponse.Referrer;
+
+            RenderHeader(orderId);
+            RenderOrderOverview(order);
+            RenderSubscription(autoOrder, rebillOrders, orderId, autoOrderEmails);
+            RenderEmails(emails);
+            RenderPageViewHistory(pageViews, sessionReferrer, pageViewOrderId, pageViewIsRedirected);
+            RenderFooter();
+        }
+
+        // =====================================================================
+        // Render helpers
+        // =====================================================================
+
+        private static void RenderHeader(string orderId)
+        {
+            Hr('=');
+            Console.WriteLine("  CHARGEBACK EVIDENCE REPORT");
+            Console.WriteLine("  UltraCart REST API v2");
+            Hr('=');
+            Console.WriteLine();
+            Kv("Order ID",  orderId);
+            Kv("Generated", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"));
+        }
+
+        private static void RenderOrderOverview(Order order)
+        {
+            Section("1. ORDER OVERVIEW");
+
+            Kv("Placed",   order.CreationDts);
+            Kv("Stage",    order.CurrentStage);
+            Kv("Currency", order.CurrencyCode);
+            if (order.Summary != null) Kv("Order Total", Money(ToDouble(order.Summary.Total), order.CurrencyCode));
+
+            Subsection("Customer");
+            OrderBilling billing = order.Billing;
+            if (billing != null)
+            {
+                Kv("Name",  JoinNonEmpty(" ", billing.FirstName, billing.LastName));
+                Kv("Email", billing.Email);
+                Kv("Phone", billing.Phone);
+            }
+            Customer cp = order.CustomerProfile;
+            Kv("Customer Profile", cp != null ? $"yes (oid {cp.CustomerProfileOid?.ToString() ?? "?"})" : "no (guest checkout)");
+            OrderMarketing marketing = order.Marketing;
+            if (marketing != null && !string.IsNullOrEmpty(marketing.OriginalSourceCode))
+                Kv("Original Source", marketing.OriginalSourceCode);
+
+            Subsection("Billing Address");
+            RenderAddress(billing?.FirstName, billing?.LastName, billing?.Company,
+                          billing?.Address1, billing?.Address2, billing?.City,
+                          billing?.State, billing?.PostalCode, billing?.CountryCode);
+
+            OrderShipping shipping = order.Shipping;
+            Subsection("Shipping Address");
+            RenderAddress(shipping?.FirstName, shipping?.LastName, shipping?.Company,
+                          shipping?.Address1, shipping?.Address2, shipping?.City,
+                          shipping?.State, shipping?.PostalCode, shipping?.CountryCode);
+
+            Subsection("Items");
+            foreach (OrderItem item in order.Items ?? new List<OrderItem>())
+            {
+                if (item.KitComponent == true) continue; // skip kit components
+                int qty = item.Quantity.HasValue ? (int)item.Quantity.Value : 0;
+                double cost = ToDouble(item.Cost);
+                Console.WriteLine(
+                    $"  {Pad(Shorten(item.MerchantItemId ?? "", 12), 12)} {Pad(Shorten(item.Description ?? "", 32), 32)} qty {qty} @ {Money(cost, order.CurrencyCode)} = {Money(qty * cost, order.CurrencyCode)}"
+                );
+            }
+
+            if (order.Summary != null)
+            {
+                Console.WriteLine();
+                Kv("Subtotal", Money(ToDouble(order.Summary.Subtotal), order.CurrencyCode));
+                if (order.Summary.Tax              != null) Kv("Tax",      Money(ToDouble(order.Summary.Tax), order.CurrencyCode));
+                if (order.Summary.ShippingHandling != null) Kv("Shipping", Money(ToDouble(order.Summary.ShippingHandling), order.CurrencyCode));
+                Kv("Total",    Money(ToDouble(order.Summary.Total), order.CurrencyCode));
+            }
+
+            Subsection("Payment");
+            OrderPayment payment = order.Payment;
+            if (payment != null)
+            {
+                Kv("Method", payment.PaymentMethod);
+                OrderPaymentCreditCard cc = payment.CreditCard;
+                if (cc != null) Kv("Card", $"{cc.CardType ?? ""} ending {cc.CardNumberTruncated ?? "????"}".Trim());
+                List<OrderPaymentTransaction> transactions = payment.Transactions ?? new List<OrderPaymentTransaction>();
+                if (transactions.Count > 0)
+                {
+                    Subsection("Transactions");
+                    foreach (OrderPaymentTransaction tx in transactions)
+                    {
+                        string status = tx.Successful == true ? "approved" : "failed";
+                        Console.WriteLine(
+                            $"  {Pad(tx.Dts ?? "", 21)} {Pad(tx.TransactionType ?? "", 12)} {Pad(Money(ToDouble(tx.Amount), order.CurrencyCode), 12)} {status}"
+                        );
+                    }
+                }
+            }
+
+            Subsection("Marketing / Attribution");
+            List<OrderUtm> utms = order.Utms ?? new List<OrderUtm>();
+            if (marketing != null) Kv("Affiliate ID", marketing.AffiliateId?.ToString() ?? "(none)");
+            if (utms.Count == 0)
+            {
+                Console.WriteLine("  No UTM clicks captured.");
+            }
+            else
+            {
+                OrderUtm mostRecent = utms[0]; // index 0 is most recent click
+                Kv("Most recent UTM source",   mostRecent.UtmSource);
+                Kv("Most recent UTM medium",   mostRecent.UtmMedium);
+                Kv("Most recent UTM campaign", mostRecent.UtmCampaign);
+                Kv("UTM clicks captured",      utms.Count.ToString());
+            }
+        }
+
+        private static void RenderSubscription(AutoOrder autoOrder, List<Order> rebillOrders, string currentOrderId, List<AutoOrderEmail> autoOrderEmails)
+        {
+            Section("2. SUBSCRIPTION DETAILS");
+
+            if (autoOrder == null)
+            {
+                Console.WriteLine("  This order is NOT part of an auto order subscription.");
+                return;
+            }
+
+            Console.WriteLine("  This order IS part of an auto order subscription.");
+            Console.WriteLine();
+            Kv("Auto Order Code", autoOrder.AutoOrderCode);
+            Kv("Status",          autoOrder.Status);
+            Kv("Enabled",         autoOrder.Enabled == true ? "yes" : "no");
+            Kv("Original Order",  autoOrder.OriginalOrderId);
+            Kv("Next Attempt",    autoOrder.NextAttempt ?? "(none scheduled)");
+            if (autoOrder.CanceledDts != null)
+            {
+                Kv("Canceled",      autoOrder.CanceledDts);
+                Kv("Canceled By",   autoOrder.CanceledByUser ?? "");
+                Kv("Cancel Reason", autoOrder.CancelReason   ?? "");
+            }
+            Kv("Total Rebills", rebillOrders.Count.ToString());
+
+            List<AutoOrderItem> aoItems = autoOrder.Items ?? new List<AutoOrderItem>();
+            if (aoItems.Count > 0)
+            {
+                Subsection("Items in Subscription");
+                foreach (AutoOrderItem aoi in aoItems)
+                {
+                    Console.WriteLine(
+                        $"  {Pad(Shorten(aoi.OriginalItemId ?? "", 12), 12)} {Pad(Shorten(aoi.OriginalItemId ?? "", 32), 32)} frequency: {aoi.Frequency ?? ""}"
+                    );
+                }
+            }
+
+            if (rebillOrders.Count > 0)
+            {
+                Subsection("Rebill Timeline");
+                List<Order> sorted = rebillOrders
+                    .OrderBy(o => o.CreationDts ?? string.Empty, StringComparer.Ordinal)
+                    .ToList();
+                foreach (Order ro in sorted)
+                {
+                    string roId    = ro.OrderId ?? "";
+                    string marker  = roId.Equals(currentOrderId, StringComparison.OrdinalIgnoreCase) ? "  *** THIS ORDER" : "";
+                    string roTotal = ro.Summary != null ? Money(ToDouble(ro.Summary.Total), ro.CurrencyCode ?? "USD") : "";
+                    Console.WriteLine(
+                        $"  {Pad(ro.CreationDts ?? "", 22)} {Pad(roId, 22)} {Pad(roTotal, 10)} {ro.CurrentStage ?? ""}{marker}"
+                    );
+                }
+            }
+
+            if (autoOrderEmails.Count > 0)
+            {
+                Subsection($"Subscription-Level Emails ({autoOrderEmails.Count})");
+                int i = 1;
+                foreach (AutoOrderEmail email in autoOrderEmails)
+                    RenderAutoOrderEmailDetail(i++, email);
+            }
+            else
+            {
+                Subsection("Subscription-Level Emails");
+                Console.WriteLine("  No subscription-level emails on record.");
+            }
+        }
+
+        private static void RenderEmails(List<OrderEmail> emails)
+        {
+            Section($"3. EMAIL DELIVERY ({emails.Count} messages)");
+            if (emails.Count == 0)
+            {
+                Console.WriteLine("  No email delivery records on file for this order.");
+                return;
+            }
+            int i = 1;
+            foreach (OrderEmail email in emails)
+                RenderOrderEmailDetail(i++, email);
+        }
+
+        private static void RenderOrderEmailDetail(int i, OrderEmail email)
+        {
+            RenderEmailDetailFields(i,
+                email.SendDts, email.Email, email.Subject, email.Internal,
+                email.Delivered, email.Skipped, email.BounceDts,
+                email.Opened, email.OpenedDts, email.Clicked, email.ClickedDts,
+                email.DeliveryDts, email.ReportingMta, email.SmtpResponse,
+                email.BounceType, email.BounceSubType, email.BounceDiagnosticCode,
+                email.SkipReason);
+        }
+
+        private static void RenderAutoOrderEmailDetail(int i, AutoOrderEmail email)
+        {
+            RenderEmailDetailFields(i,
+                email.SendDts, email.Email, email.Subject, email.Internal,
+                email.Delivered, email.Skipped, email.BounceDts,
+                email.Opened, email.OpenedDts, email.Clicked, email.ClickedDts,
+                email.DeliveryDts, email.ReportingMta, email.SmtpResponse,
+                email.BounceType, email.BounceSubType, email.BounceDiagnosticCode,
+                email.SkipReason);
+        }
+
+        private static void RenderEmailDetailFields(int i,
+            string sendDts, string emailAddr, string subject, bool? internal_,
+            bool? delivered, bool? skipped, string bounceDts,
+            bool? opened, string openedDts, bool? clicked, string clickedDts,
+            string deliveryDts, string reportingMta, string smtpResponse,
+            string bounceType, string bounceSubType, string bounceDiagnostic,
+            string skipReason)
+        {
+            string internalNote = internal_ == true ? "   (internal copy)" : "";
+            Console.WriteLine($"  [{i}] sent {sendDts ?? "?"}{internalNote}");
+            Console.WriteLine($"      To:               {emailAddr ?? ""}");
+            Console.WriteLine($"      Subject:          {subject   ?? ""}");
+
+            List<string> states = new List<string>();
+            if (delivered == true)            states.Add("DELIVERED");
+            if (skipped   == true)            states.Add("SKIPPED");
+            if (bounceDts != null)            states.Add($"BOUNCED {bounceDts}");
+            if (opened    == true)            states.Add($"OPENED {openedDts ?? ""}");
+            if (clicked   == true)            states.Add($"CLICKED {clickedDts ?? ""}");
+            Console.WriteLine($"      Status:           {(states.Count == 0 ? "unknown" : string.Join(", ", states))}");
+
+            if (deliveryDts      != null) Console.WriteLine($"      Delivered:        {deliveryDts}");
+            if (reportingMta     != null) Console.WriteLine($"      Reporting MTA:    {reportingMta}");
+            if (smtpResponse     != null) Console.WriteLine($"      SMTP response:    {smtpResponse}");
+            if (bounceType       != null) Console.WriteLine($"      Bounce type:      {bounceType} / {bounceSubType ?? ""}");
+            if (bounceDiagnostic != null) Console.WriteLine($"      Diagnostic:       {bounceDiagnostic}");
+            if (skipReason       != null) Console.WriteLine($"      Skip reason:      {skipReason}");
+            Console.WriteLine();
+        }
+
+        private static void RenderPageViewHistory(List<OrderPageView> pageViews, string sessionReferrer, string sourceOrderId, bool isRedirected)
+        {
+            Section($"4. PAGE VIEW HISTORY ({pageViews.Count} views)");
+            if (isRedirected)
+            {
+                Console.WriteLine("  Note: this is a subscription rebill. The disputed order itself has no");
+                Console.WriteLine("  checkout session of its own. The page views below are from the ORIGINAL");
+                Console.WriteLine("  order that started the subscription, where the customer's intent was");
+                Console.WriteLine("  captured during signup.");
+                Console.WriteLine();
+                Kv("Source order", sourceOrderId);
+            }
+            Kv("Session referrer", sessionReferrer ?? "(direct or unknown)");
+
+            if (pageViews.Count == 0)
+            {
+                Console.WriteLine();
+                Console.WriteLine("  No page views captured" + (isRedirected ? " for the original order." : " for this order's session."));
+                return;
+            }
+
+            Subsection("Timeline");
+            foreach (OrderPageView pv in pageViews)
+            {
+                string tops = pv.TimeOnPage.HasValue ? $"{pv.TimeOnPage.Value,4}s" : "   -";
+                Console.WriteLine($"  {Pad(pv.ViewDts ?? "", 22)} {tops}   {pv.Url ?? ""}");
+            }
+
+            if (pageViews.Count >= 2)
+            {
+                if (DateTime.TryParse(pageViews[0].ViewDts, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTime first) &&
+                    DateTime.TryParse(pageViews[pageViews.Count - 1].ViewDts, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTime last) &&
+                    last > first)
+                {
+                    int elapsed = (int)(last - first).TotalSeconds;
+                    int mins = elapsed / 60;
+                    int secs = elapsed % 60;
+                    Console.WriteLine();
+                    Kv("Session length", $"{mins}m {secs}s (first view to last view)");
+                }
+            }
+
+            HashSet<string> uniqueUrls = new HashSet<string>(pageViews.Where(pv => !string.IsNullOrEmpty(pv.Url)).Select(pv => pv.Url));
+            Kv("Unique URLs visited", uniqueUrls.Count.ToString());
+        }
+
+        private static void RenderAddress(string firstName, string lastName, string company,
+                                           string addr1, string addr2, string city, string state,
+                                           string postalCode, string countryCode)
+        {
+            if (string.IsNullOrEmpty(firstName) && string.IsNullOrEmpty(lastName)
+                && string.IsNullOrEmpty(addr1)  && string.IsNullOrEmpty(city))
+            {
+                Console.WriteLine("  (none on file)");
+                return;
+            }
+
+            string name = JoinNonEmpty(" ", firstName, lastName);
+            string cityRow = ((city ?? "") + (string.IsNullOrEmpty(state) ? "" : ", " + state) + " " + (postalCode ?? "")).Trim();
+            foreach (string line in new[] { name, company, addr1, addr2, cityRow, countryCode })
+            {
+                if (!string.IsNullOrWhiteSpace(line)) Console.WriteLine("  " + line);
+            }
+        }
+
+        private static void RenderFooter()
+        {
+            Console.WriteLine();
+            Hr('=');
+            Console.WriteLine("  END OF EVIDENCE REPORT");
+            Hr('=');
+        }
+
+        // =====================================================================
+        // Tiny formatting primitives
+        // =====================================================================
+
+        private static void Hr(char c) => Console.WriteLine(new string(c, 80));
+
+        private static void Section(string title)
+        {
+            Console.WriteLine();
+            Hr('=');
+            Console.WriteLine("  " + title);
+            Hr('=');
+            Console.WriteLine();
+        }
+
+        private static void Subsection(string title)
+        {
+            Console.WriteLine();
+            Console.WriteLine("  " + title);
+            Console.WriteLine("  " + new string('-', title.Length));
+        }
+
+        private static void Kv(string label, object value)
+        {
+            string val = value == null ? "" : value.ToString();
+            Console.WriteLine($"  {(label + ":").PadRight(22)} {val}");
+        }
+
+        private static string Pad(string s, int n)
+        {
+            s = s ?? "";
+            return s.Length >= n ? s : s + new string(' ', n - s.Length);
+        }
+
+        private static string Shorten(string s, int n)
+        {
+            s = s ?? "";
+            return s.Length <= n ? s : s.Substring(0, n - 1) + "~";
+        }
+
+        private static string JoinNonEmpty(string sep, params string[] parts)
+        {
+            return string.Join(sep, parts.Where(p => !string.IsNullOrEmpty(p)));
+        }
+
+        private static double ToDouble(decimal? d) => d.HasValue ? (double)d.Value : 0.0;
+
+        private static string Money(double amount, string currency)
+        {
+            string sign = amount < 0 ? "-" : "";
+            return $"{sign}${Math.Abs(amount):N2} {currency ?? ""}".Trim();
+        }
+
+        private static void FailOp(string operation, com.ultracart.admin.v2.Model.Error error)
+        {
+            Console.Error.WriteLine($"ERROR in {operation}:");
+            Console.Error.WriteLine($"  Developer message: {error.DeveloperMessage ?? ""}");
+            Console.Error.WriteLine($"  User message:      {error.UserMessage      ?? ""}");
+            Environment.Exit(1);
+        }
+    }
+}

--- a/csharp/order/GetChargebackEvidence.cs
+++ b/csharp/order/GetChargebackEvidence.cs
@@ -152,7 +152,7 @@ namespace SdkSample.order
             Kv("Placed",   order.CreationDts);
             Kv("Stage",    order.CurrentStage);
             Kv("Currency", order.CurrencyCode);
-            if (order.Summary != null) Kv("Order Total", Money(ToDouble(order.Summary.Total), order.CurrencyCode));
+            if (order.Summary != null) Kv("Order Total", Money(ToDouble(MoneyValue(order.Summary.Total)), order.CurrencyCode));
 
             Subsection("Customer");
             OrderBilling billing = order.Billing;
@@ -160,31 +160,34 @@ namespace SdkSample.order
             {
                 Kv("Name",  JoinNonEmpty(" ", billing.FirstName, billing.LastName));
                 Kv("Email", billing.Email);
-                Kv("Phone", billing.Phone);
+                // First populated phone wins
+                Kv("Phone", billing.DayPhone ?? billing.EveningPhone ?? billing.CellPhone);
             }
             Customer cp = order.CustomerProfile;
             Kv("Customer Profile", cp != null ? $"yes (oid {cp.CustomerProfileOid?.ToString() ?? "?"})" : "no (guest checkout)");
             OrderMarketing marketing = order.Marketing;
-            if (marketing != null && !string.IsNullOrEmpty(marketing.OriginalSourceCode))
-                Kv("Original Source", marketing.OriginalSourceCode);
+            if (marketing != null && !string.IsNullOrEmpty(marketing.AdvertisingSource))
+                Kv("Advertising Source", marketing.AdvertisingSource);
+            if (marketing != null && !string.IsNullOrEmpty(marketing.ReferralCode))
+                Kv("Referral Code", marketing.ReferralCode);
 
             Subsection("Billing Address");
             RenderAddress(billing?.FirstName, billing?.LastName, billing?.Company,
                           billing?.Address1, billing?.Address2, billing?.City,
-                          billing?.State, billing?.PostalCode, billing?.CountryCode);
+                          billing?.StateRegion, billing?.PostalCode, billing?.CountryCode);
 
             OrderShipping shipping = order.Shipping;
             Subsection("Shipping Address");
             RenderAddress(shipping?.FirstName, shipping?.LastName, shipping?.Company,
                           shipping?.Address1, shipping?.Address2, shipping?.City,
-                          shipping?.State, shipping?.PostalCode, shipping?.CountryCode);
+                          shipping?.StateRegion, shipping?.PostalCode, shipping?.CountryCode);
 
             Subsection("Items");
             foreach (OrderItem item in order.Items ?? new List<OrderItem>())
             {
                 if (item.KitComponent == true) continue; // skip kit components
                 int qty = item.Quantity.HasValue ? (int)item.Quantity.Value : 0;
-                double cost = ToDouble(item.Cost);
+                double cost = ToDouble(MoneyValue(item.Cost)); // OrderItem.Cost is a Currency
                 Console.WriteLine(
                     $"  {Pad(Shorten(item.MerchantItemId ?? "", 12), 12)} {Pad(Shorten(item.Description ?? "", 32), 32)} qty {qty} @ {Money(cost, order.CurrencyCode)} = {Money(qty * cost, order.CurrencyCode)}"
                 );
@@ -193,10 +196,10 @@ namespace SdkSample.order
             if (order.Summary != null)
             {
                 Console.WriteLine();
-                Kv("Subtotal", Money(ToDouble(order.Summary.Subtotal), order.CurrencyCode));
-                if (order.Summary.Tax              != null) Kv("Tax",      Money(ToDouble(order.Summary.Tax), order.CurrencyCode));
-                if (order.Summary.ShippingHandling != null) Kv("Shipping", Money(ToDouble(order.Summary.ShippingHandling), order.CurrencyCode));
-                Kv("Total",    Money(ToDouble(order.Summary.Total), order.CurrencyCode));
+                Kv("Subtotal", Money(ToDouble(MoneyValue(order.Summary.Subtotal)), order.CurrencyCode));
+                if (order.Summary.Tax                   != null) Kv("Tax",      Money(ToDouble(MoneyValue(order.Summary.Tax)), order.CurrencyCode));
+                if (order.Summary.ShippingHandlingTotal != null) Kv("Shipping", Money(ToDouble(MoneyValue(order.Summary.ShippingHandlingTotal)), order.CurrencyCode));
+                Kv("Total",    Money(ToDouble(MoneyValue(order.Summary.Total)), order.CurrencyCode));
             }
 
             Subsection("Payment");
@@ -214,7 +217,7 @@ namespace SdkSample.order
                     {
                         string status = tx.Successful == true ? "approved" : "failed";
                         Console.WriteLine(
-                            $"  {Pad(tx.Dts ?? "", 21)} {Pad(tx.TransactionType ?? "", 12)} {Pad(Money(ToDouble(tx.Amount), order.CurrencyCode), 12)} {status}"
+                            $"  {Pad(tx.TransactionTimestamp ?? "", 21)} {Pad(Shorten(tx.TransactionGateway ?? "", 30), 30)} {status}"
                         );
                     }
                 }
@@ -222,7 +225,8 @@ namespace SdkSample.order
 
             Subsection("Marketing / Attribution");
             List<OrderUtm> utms = order.Utms ?? new List<OrderUtm>();
-            if (marketing != null) Kv("Affiliate ID", marketing.AffiliateId?.ToString() ?? "(none)");
+            // Affiliate attribution lives on OrderAffiliate (expansion=affiliate); not pulled
+            // here to keep the chargeback request light.
             if (utms.Count == 0)
             {
                 Console.WriteLine("  No UTM clicks captured.");
@@ -488,7 +492,15 @@ namespace SdkSample.order
             return string.Join(sep, parts.Where(p => !string.IsNullOrEmpty(p)));
         }
 
-        private static double ToDouble(decimal? d) => d.HasValue ? (double)d.Value : 0.0;
+        // SDK money fields are Currency objects, not raw numbers. Pull the localized
+        // value off; null-safe for missing/optional fields.
+        private static double? MoneyValue(Currency c)
+        {
+            if (c == null || !c.Localized.HasValue) return null;
+            return (double)c.Localized.Value;
+        }
+
+        private static double ToDouble(double? d) => d.HasValue ? d.Value : 0.0;
 
         private static string Money(double amount, string currency)
         {

--- a/csharp/packages.config
+++ b/csharp/packages.config
@@ -16,5 +16,5 @@
   <package id="System.Text.Json" version="9.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
-  <package id="com.ultracart.admin.v2" version="4.1.15" targetFramework="net48" />
+  <package id="com.ultracart.admin.v2" version="4.1.88" targetFramework="net48" />
 </packages>

--- a/java/src/order/GetChargebackEvidence.java
+++ b/java/src/order/GetChargebackEvidence.java
@@ -144,19 +144,24 @@ public class GetChargebackEvidence {
         kv("Placed",   order.getCreationDts());
         kv("Stage",    order.getCurrentStage());
         kv("Currency", order.getCurrencyCode());
-        if (order.getSummary() != null) kv("Order Total", money(toDouble(order.getSummary().getTotal()), order.getCurrencyCode()));
+        if (order.getSummary() != null) kv("Order Total", money(toDouble(moneyValue(order.getSummary().getTotal())), order.getCurrencyCode()));
 
         subsection("Customer");
         OrderBilling billing = order.getBilling();
         if (billing != null) {
             kv("Name",  joinNonEmpty(" ", billing.getFirstName(), billing.getLastName()));
             kv("Email", billing.getEmail());
-            kv("Phone", billing.getPhone());
+            // First populated phone wins
+            String phone = billing.getDayPhone() != null ? billing.getDayPhone()
+                : billing.getEveningPhone() != null ? billing.getEveningPhone()
+                : billing.getCellPhone();
+            kv("Phone", phone);
         }
         Customer cp = order.getCustomerProfile();
         kv("Customer Profile", cp != null ? "yes (oid " + (cp.getCustomerProfileOid() != null ? cp.getCustomerProfileOid() : "?") + ")" : "no (guest checkout)");
         OrderMarketing marketing = order.getMarketing();
-        if (marketing != null && marketing.getOriginalSourceCode() != null) kv("Original Source", marketing.getOriginalSourceCode());
+        if (marketing != null && marketing.getAdvertisingSource() != null) kv("Advertising Source", marketing.getAdvertisingSource());
+        if (marketing != null && marketing.getReferralCode() != null)      kv("Referral Code", marketing.getReferralCode());
 
         subsection("Billing Address");
         renderAddress(billing != null ? billing.getFirstName() : null,
@@ -165,7 +170,7 @@ public class GetChargebackEvidence {
                       billing != null ? billing.getAddress1()  : null,
                       billing != null ? billing.getAddress2()  : null,
                       billing != null ? billing.getCity()      : null,
-                      billing != null ? billing.getState()     : null,
+                      billing != null ? billing.getStateRegion() : null,
                       billing != null ? billing.getPostalCode(): null,
                       billing != null ? billing.getCountryCode() : null);
 
@@ -177,7 +182,7 @@ public class GetChargebackEvidence {
                       shipping != null ? shipping.getAddress1()  : null,
                       shipping != null ? shipping.getAddress2()  : null,
                       shipping != null ? shipping.getCity()      : null,
-                      shipping != null ? shipping.getState()     : null,
+                      shipping != null ? shipping.getStateRegion() : null,
                       shipping != null ? shipping.getPostalCode(): null,
                       shipping != null ? shipping.getCountryCode() : null);
 
@@ -186,7 +191,7 @@ public class GetChargebackEvidence {
         for (OrderItem item : items) {
             if (Boolean.TRUE.equals(item.getKitComponent())) continue; // skip kit components - sub-rows of a parent kit
             int qty     = item.getQuantity() != null ? item.getQuantity().intValue() : 0;
-            double cost = toDouble(item.getCost());
+            double cost = toDouble(moneyValue(item.getCost())); // OrderItem.cost is a Currency
             System.out.printf("  %-12s %-32s qty %d @ %s = %s%n",
                 shorten(safeStr(item.getMerchantItemId()), 12),
                 shorten(safeStr(item.getDescription()), 32),
@@ -198,10 +203,10 @@ public class GetChargebackEvidence {
 
         if (order.getSummary() != null) {
             System.out.println();
-            kv("Subtotal", money(toDouble(order.getSummary().getSubtotal()), order.getCurrencyCode()));
-            if (order.getSummary().getTax() != null)              kv("Tax",      money(toDouble(order.getSummary().getTax()), order.getCurrencyCode()));
-            if (order.getSummary().getShippingHandling() != null) kv("Shipping", money(toDouble(order.getSummary().getShippingHandling()), order.getCurrencyCode()));
-            kv("Total",    money(toDouble(order.getSummary().getTotal()), order.getCurrencyCode()));
+            kv("Subtotal", money(toDouble(moneyValue(order.getSummary().getSubtotal())), order.getCurrencyCode()));
+            if (moneyValue(order.getSummary().getTax()) != null)              kv("Tax",      money(toDouble(moneyValue(order.getSummary().getTax())), order.getCurrencyCode()));
+            if (moneyValue(order.getSummary().getShippingHandlingTotal()) != null) kv("Shipping", money(toDouble(moneyValue(order.getSummary().getShippingHandlingTotal())), order.getCurrencyCode()));
+            kv("Total",    money(toDouble(moneyValue(order.getSummary().getTotal())), order.getCurrencyCode()));
         }
 
         subsection("Payment");
@@ -215,10 +220,9 @@ public class GetChargebackEvidence {
                 subsection("Transactions");
                 for (OrderPaymentTransaction tx : transactions) {
                     String status = Boolean.TRUE.equals(tx.getSuccessful()) ? "approved" : "failed";
-                    System.out.printf("  %-21s %-12s %-12s %s%n",
-                        safeStr(tx.getDts()),
-                        safeStr(tx.getTransactionType()),
-                        money(toDouble(tx.getAmount()), order.getCurrencyCode()),
+                    System.out.printf("  %-21s %-30s %s%n",
+                        safeStr(tx.getTransactionTimestamp()),
+                        shorten(safeStr(tx.getTransactionGateway()), 30),
                         status
                     );
                 }
@@ -227,7 +231,8 @@ public class GetChargebackEvidence {
 
         subsection("Marketing / Attribution");
         List<OrderUtm> utms = order.getUtms() != null ? order.getUtms() : Collections.emptyList();
-        if (marketing != null) kv("Affiliate ID", marketing.getAffiliateId() != null ? marketing.getAffiliateId().toString() : "(none)");
+        // Affiliate attribution lives on OrderAffiliate (expansion=affiliate); not pulled
+        // here to keep the chargeback request light.
         if (utms.isEmpty()) {
             System.out.println("  No UTM clicks captured.");
         } else {
@@ -279,7 +284,7 @@ public class GetChargebackEvidence {
             for (Order ro : sorted) {
                 String roId    = safeStr(ro.getOrderId());
                 String marker  = roId.equalsIgnoreCase(currentOrderId) ? "  *** THIS ORDER" : "";
-                String roTotal = ro.getSummary() != null ? money(toDouble(ro.getSummary().getTotal()), ro.getCurrencyCode() != null ? ro.getCurrencyCode() : "USD") : "";
+                String roTotal = ro.getSummary() != null ? money(toDouble(moneyValue(ro.getSummary().getTotal())), ro.getCurrencyCode() != null ? ro.getCurrencyCode() : "USD") : "";
                 System.out.printf("  %-22s %-22s %-10s %s%s%n",
                     safeStr(ro.getCreationDts()),
                     roId,
@@ -483,8 +488,15 @@ public class GetChargebackEvidence {
         return sb.toString();
     }
 
-    private static double toDouble(java.math.BigDecimal bd) {
-        return bd != null ? bd.doubleValue() : 0.0;
+    // SDK money fields are Currency objects, not raw numbers. Pull the localized
+    // value off; null-safe for missing/optional fields.
+    private static Double moneyValue(Currency c) {
+        if (c == null || c.getLocalized() == null) return null;
+        return c.getLocalized().doubleValue();
+    }
+
+    private static double toDouble(Double d) {
+        return d != null ? d : 0.0;
     }
 
     private static String money(double amount, String currency) {

--- a/java/src/order/GetChargebackEvidence.java
+++ b/java/src/order/GetChargebackEvidence.java
@@ -1,0 +1,501 @@
+package order;
+
+import com.ultracart.admin.v2.AutoOrderApi;
+import com.ultracart.admin.v2.OrderApi;
+import com.ultracart.admin.v2.models.*;
+import com.ultracart.admin.v2.util.ApiException;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.*;
+
+/**
+ * GetChargebackEvidence
+ *
+ * Pulls everything from UltraCart that is useful when fighting a chargeback
+ * dispute and prints a formatted evidence report. Designed as a starting point
+ * for building the actual evidence packet you submit to the card processor.
+ *
+ * What this sample demonstrates:
+ *   1. Order detail with the SPECIFIC expansions a chargeback case relies on.
+ *      Notice we list every expansion explicitly - no shortcuts. Listing them
+ *      individually keeps your payload small and forces you to think about
+ *      what evidence each one represents.
+ *   2. Email delivery records via the dedicated /emails endpoint (not via
+ *      expansion). Use the dedicated endpoint for chargeback work - it is the
+ *      canonical full-fidelity source for SES delivery events on every order.
+ *   3. Page view history (the customer was on your site, navigated through
+ *      pages, spent time before placing the order).
+ *   4. Auto-order detection: a large fraction of chargebacks are subscription
+ *      disputes. When the order is part of an auto order, the sample pulls
+ *      the parent subscription, every rebill, and the auto-order-level email
+ *      log. For rebills specifically, the page-view lookup pivots to the
+ *      ORIGINAL order (the rebill itself has no checkout session).
+ *
+ * Requires the May 2026 SDK build with getOrderEmails,
+ * getOrderPageViewHistory, and getAutoOrderEmails.
+ */
+public class GetChargebackEvidence {
+
+    private static final String ORDER_EXPANSION = String.join(",",
+        "billing",                  // address customer entered for billing
+        "shipping",                 // address goods shipped to
+        "payment",                  // payment method, card last four, gateway info
+        "payment.transaction",      // auth/capture/refund timeline
+        "summary",                  // totals, tax, shipping, weights
+        "items",                    // line items the customer ordered
+        "coupon",                   // discounts the customer chose to apply
+        "customer_profile",         // returning-customer signal, account history
+        "auto_order",               // detect subscription chargebacks
+        "utms",                     // entry-path UTM clicks (attribution chain)
+        "marketing",                // affiliate / source-code attribution
+        "gift",                     // gift-giving intent if applicable
+        "point_of_sale",            // POS terminal / location for retail orders
+        "channel_partner"           // channel partner data
+    );
+
+    private static final String AUTO_ORDER_EXPANSION = String.join(",",
+        "items",                    // subscription line items + frequency
+        "rebill_orders",            // every rebill that has occurred
+        "logs",                     // status changes, payment attempts, cancellations
+        "management"                // self-service management state
+    );
+
+    public void execute() throws ApiException {
+        execute("DEMO-0009104976");
+    }
+
+    public void execute(String orderId) throws ApiException {
+        OrderApi orderApi = new OrderApi(common.Constants.API_KEY);
+        AutoOrderApi autoOrderApi = new AutoOrderApi(common.Constants.API_KEY);
+
+        // Order detail
+        OrderResponse orderResponse = orderApi.getOrder(orderId, ORDER_EXPANSION);
+        if (orderResponse.getError() != null) failOp("getOrder", orderResponse.getError());
+        Order order = orderResponse.getOrder();
+
+        // Use the dedicated /emails endpoint rather than _expand=emails. The
+        // dedicated endpoint is the canonical full-fidelity source for SES
+        // delivery events.
+        OrderEmailsResponse emailsResponse = orderApi.getOrderEmails(orderId);
+        if (emailsResponse.getError() != null) failOp("getOrderEmails", emailsResponse.getError());
+        List<OrderEmail> emails = emailsResponse.getEmails() != null ? emailsResponse.getEmails() : Collections.emptyList();
+
+        // Auto-order chain BEFORE page views: a rebill's own page view history
+        // is empty - the meaningful history lives on the original order.
+        AutoOrder autoOrder = null;
+        List<AutoOrderEmail> autoOrderEmails = Collections.emptyList();
+        List<Order> rebillOrders = Collections.emptyList();
+        OrderAutoOrder autoOrderPointer = order.getAutoOrder();
+        if (autoOrderPointer != null && autoOrderPointer.getAutoOrderOid() != null) {
+            int autoOrderOid = autoOrderPointer.getAutoOrderOid();
+
+            AutoOrderResponse aoResponse = autoOrderApi.getAutoOrder(autoOrderOid, AUTO_ORDER_EXPANSION);
+            if (aoResponse.getError() != null) failOp("getAutoOrder", aoResponse.getError());
+            autoOrder = aoResponse.getAutoOrder();
+            rebillOrders = autoOrder.getRebillOrders() != null ? autoOrder.getRebillOrders() : Collections.emptyList();
+
+            AutoOrderEmailsResponse aoEmailsResponse = autoOrderApi.getAutoOrderEmails(autoOrderOid);
+            if (aoEmailsResponse.getError() != null) failOp("getAutoOrderEmails", aoEmailsResponse.getError());
+            autoOrderEmails = aoEmailsResponse.getEmails() != null ? aoEmailsResponse.getEmails() : Collections.emptyList();
+        }
+
+        // For a rebill chargeback, page views live on the ORIGINAL order.
+        String pageViewOrderId = orderId;
+        boolean pageViewIsRedirected = false;
+        if (autoOrder != null
+                && autoOrder.getOriginalOrderId() != null
+                && !autoOrder.getOriginalOrderId().equalsIgnoreCase(orderId)) {
+            pageViewOrderId = autoOrder.getOriginalOrderId();
+            pageViewIsRedirected = true;
+        }
+
+        OrderPageViewHistoryResponse pageViewResponse = orderApi.getOrderPageViewHistory(pageViewOrderId);
+        if (pageViewResponse.getError() != null) failOp("getOrderPageViewHistory", pageViewResponse.getError());
+        List<OrderPageView> pageViews = pageViewResponse.getPageViews() != null ? pageViewResponse.getPageViews() : Collections.emptyList();
+        String sessionReferrer = pageViewResponse.getReferrer();
+
+        renderHeader(orderId);
+        renderOrderOverview(order);
+        renderSubscription(autoOrder, rebillOrders, orderId, autoOrderEmails);
+        renderEmails(emails);
+        renderPageViewHistory(pageViews, sessionReferrer, pageViewOrderId, pageViewIsRedirected);
+        renderFooter();
+    }
+
+    // =====================================================================
+    // Render helpers
+    // =====================================================================
+
+    private void renderHeader(String orderId) {
+        hr('=');
+        System.out.println("  CHARGEBACK EVIDENCE REPORT");
+        System.out.println("  UltraCart REST API v2");
+        hr('=');
+        System.out.println();
+        kv("Order ID",  orderId);
+        kv("Generated", Instant.now().toString());
+    }
+
+    private void renderOrderOverview(Order order) {
+        section("1. ORDER OVERVIEW");
+
+        kv("Placed",   order.getCreationDts());
+        kv("Stage",    order.getCurrentStage());
+        kv("Currency", order.getCurrencyCode());
+        if (order.getSummary() != null) kv("Order Total", money(toDouble(order.getSummary().getTotal()), order.getCurrencyCode()));
+
+        subsection("Customer");
+        OrderBilling billing = order.getBilling();
+        if (billing != null) {
+            kv("Name",  joinNonEmpty(" ", billing.getFirstName(), billing.getLastName()));
+            kv("Email", billing.getEmail());
+            kv("Phone", billing.getPhone());
+        }
+        Customer cp = order.getCustomerProfile();
+        kv("Customer Profile", cp != null ? "yes (oid " + (cp.getCustomerProfileOid() != null ? cp.getCustomerProfileOid() : "?") + ")" : "no (guest checkout)");
+        OrderMarketing marketing = order.getMarketing();
+        if (marketing != null && marketing.getOriginalSourceCode() != null) kv("Original Source", marketing.getOriginalSourceCode());
+
+        subsection("Billing Address");
+        renderAddress(billing != null ? billing.getFirstName() : null,
+                      billing != null ? billing.getLastName()  : null,
+                      billing != null ? billing.getCompany()   : null,
+                      billing != null ? billing.getAddress1()  : null,
+                      billing != null ? billing.getAddress2()  : null,
+                      billing != null ? billing.getCity()      : null,
+                      billing != null ? billing.getState()     : null,
+                      billing != null ? billing.getPostalCode(): null,
+                      billing != null ? billing.getCountryCode() : null);
+
+        OrderShipping shipping = order.getShipping();
+        subsection("Shipping Address");
+        renderAddress(shipping != null ? shipping.getFirstName() : null,
+                      shipping != null ? shipping.getLastName()  : null,
+                      shipping != null ? shipping.getCompany()   : null,
+                      shipping != null ? shipping.getAddress1()  : null,
+                      shipping != null ? shipping.getAddress2()  : null,
+                      shipping != null ? shipping.getCity()      : null,
+                      shipping != null ? shipping.getState()     : null,
+                      shipping != null ? shipping.getPostalCode(): null,
+                      shipping != null ? shipping.getCountryCode() : null);
+
+        subsection("Items");
+        List<OrderItem> items = order.getItems() != null ? order.getItems() : Collections.emptyList();
+        for (OrderItem item : items) {
+            if (Boolean.TRUE.equals(item.getKitComponent())) continue; // skip kit components - sub-rows of a parent kit
+            int qty     = item.getQuantity() != null ? item.getQuantity().intValue() : 0;
+            double cost = toDouble(item.getCost());
+            System.out.printf("  %-12s %-32s qty %d @ %s = %s%n",
+                shorten(safeStr(item.getMerchantItemId()), 12),
+                shorten(safeStr(item.getDescription()), 32),
+                qty,
+                money(cost, order.getCurrencyCode()),
+                money(qty * cost, order.getCurrencyCode())
+            );
+        }
+
+        if (order.getSummary() != null) {
+            System.out.println();
+            kv("Subtotal", money(toDouble(order.getSummary().getSubtotal()), order.getCurrencyCode()));
+            if (order.getSummary().getTax() != null)              kv("Tax",      money(toDouble(order.getSummary().getTax()), order.getCurrencyCode()));
+            if (order.getSummary().getShippingHandling() != null) kv("Shipping", money(toDouble(order.getSummary().getShippingHandling()), order.getCurrencyCode()));
+            kv("Total",    money(toDouble(order.getSummary().getTotal()), order.getCurrencyCode()));
+        }
+
+        subsection("Payment");
+        OrderPayment payment = order.getPayment();
+        if (payment != null) {
+            kv("Method", payment.getPaymentMethod());
+            OrderPaymentCreditCard cc = payment.getCreditCard();
+            if (cc != null) kv("Card", (safeStr(cc.getCardType()) + " ending " + (cc.getCardNumberTruncated() != null ? cc.getCardNumberTruncated() : "????")).trim());
+            List<OrderPaymentTransaction> transactions = payment.getTransactions() != null ? payment.getTransactions() : Collections.emptyList();
+            if (!transactions.isEmpty()) {
+                subsection("Transactions");
+                for (OrderPaymentTransaction tx : transactions) {
+                    String status = Boolean.TRUE.equals(tx.getSuccessful()) ? "approved" : "failed";
+                    System.out.printf("  %-21s %-12s %-12s %s%n",
+                        safeStr(tx.getDts()),
+                        safeStr(tx.getTransactionType()),
+                        money(toDouble(tx.getAmount()), order.getCurrencyCode()),
+                        status
+                    );
+                }
+            }
+        }
+
+        subsection("Marketing / Attribution");
+        List<OrderUtm> utms = order.getUtms() != null ? order.getUtms() : Collections.emptyList();
+        if (marketing != null) kv("Affiliate ID", marketing.getAffiliateId() != null ? marketing.getAffiliateId().toString() : "(none)");
+        if (utms.isEmpty()) {
+            System.out.println("  No UTM clicks captured.");
+        } else {
+            OrderUtm mostRecent = utms.get(0); // index 0 is most recent click
+            kv("Most recent UTM source",   mostRecent.getUtmSource());
+            kv("Most recent UTM medium",   mostRecent.getUtmMedium());
+            kv("Most recent UTM campaign", mostRecent.getUtmCampaign());
+            kv("UTM clicks captured",      String.valueOf(utms.size()));
+        }
+    }
+
+    private void renderSubscription(AutoOrder autoOrder, List<Order> rebillOrders, String currentOrderId, List<AutoOrderEmail> autoOrderEmails) {
+        section("2. SUBSCRIPTION DETAILS");
+        if (autoOrder == null) {
+            System.out.println("  This order is NOT part of an auto order subscription.");
+            return;
+        }
+
+        System.out.println("  This order IS part of an auto order subscription.");
+        System.out.println();
+        kv("Auto Order Code", autoOrder.getAutoOrderCode());
+        kv("Status",          autoOrder.getStatus());
+        kv("Enabled",         Boolean.TRUE.equals(autoOrder.getEnabled()) ? "yes" : "no");
+        kv("Original Order",  autoOrder.getOriginalOrderId());
+        kv("Next Attempt",    autoOrder.getNextAttempt() != null ? autoOrder.getNextAttempt() : "(none scheduled)");
+        if (autoOrder.getCanceledDts() != null) {
+            kv("Canceled",      autoOrder.getCanceledDts());
+            kv("Canceled By",   safeStr(autoOrder.getCanceledByUser()));
+            kv("Cancel Reason", safeStr(autoOrder.getCancelReason()));
+        }
+        kv("Total Rebills", String.valueOf(rebillOrders.size()));
+
+        List<AutoOrderItem> aoItems = autoOrder.getItems() != null ? autoOrder.getItems() : Collections.emptyList();
+        if (!aoItems.isEmpty()) {
+            subsection("Items in Subscription");
+            for (AutoOrderItem aoi : aoItems) {
+                System.out.printf("  %-12s %-32s frequency: %s%n",
+                    shorten(safeStr(aoi.getOriginalItemId()), 12),
+                    shorten(safeStr(aoi.getOriginalItemId()), 32),
+                    safeStr(aoi.getFrequency())
+                );
+            }
+        }
+
+        if (!rebillOrders.isEmpty()) {
+            subsection("Rebill Timeline");
+            List<Order> sorted = new ArrayList<>(rebillOrders);
+            sorted.sort(Comparator.comparing(o -> safeStr(o.getCreationDts())));
+            for (Order ro : sorted) {
+                String roId    = safeStr(ro.getOrderId());
+                String marker  = roId.equalsIgnoreCase(currentOrderId) ? "  *** THIS ORDER" : "";
+                String roTotal = ro.getSummary() != null ? money(toDouble(ro.getSummary().getTotal()), ro.getCurrencyCode() != null ? ro.getCurrencyCode() : "USD") : "";
+                System.out.printf("  %-22s %-22s %-10s %s%s%n",
+                    safeStr(ro.getCreationDts()),
+                    roId,
+                    roTotal,
+                    safeStr(ro.getCurrentStage()),
+                    marker
+                );
+            }
+        }
+
+        if (!autoOrderEmails.isEmpty()) {
+            subsection("Subscription-Level Emails (" + autoOrderEmails.size() + ")");
+            int i = 1;
+            for (AutoOrderEmail email : autoOrderEmails) {
+                renderAutoOrderEmailDetail(i++, email);
+            }
+        } else {
+            subsection("Subscription-Level Emails");
+            System.out.println("  No subscription-level emails on record.");
+        }
+    }
+
+    private void renderEmails(List<OrderEmail> emails) {
+        section("3. EMAIL DELIVERY (" + emails.size() + " messages)");
+        if (emails.isEmpty()) {
+            System.out.println("  No email delivery records on file for this order.");
+            return;
+        }
+        int i = 1;
+        for (OrderEmail email : emails) {
+            renderOrderEmailDetail(i++, email);
+        }
+    }
+
+    private void renderOrderEmailDetail(int i, OrderEmail email) {
+        renderEmailDetailFields(i,
+            email.getSendDts(), email.getEmail(), email.getSubject(), email.isInternal(),
+            email.isDelivered(), email.isSkipped(), email.getBounceDts(),
+            email.isOpened(), email.getOpenedDts(), email.isClicked(), email.getClickedDts(),
+            email.getDeliveryDts(), email.getReportingMta(), email.getSmtpResponse(),
+            email.getBounceType(), email.getBounceSubType(), email.getBounceDiagnosticCode(),
+            email.getSkipReason()
+        );
+    }
+
+    private void renderAutoOrderEmailDetail(int i, AutoOrderEmail email) {
+        renderEmailDetailFields(i,
+            email.getSendDts(), email.getEmail(), email.getSubject(), email.isInternal(),
+            email.isDelivered(), email.isSkipped(), email.getBounceDts(),
+            email.isOpened(), email.getOpenedDts(), email.isClicked(), email.getClickedDts(),
+            email.getDeliveryDts(), email.getReportingMta(), email.getSmtpResponse(),
+            email.getBounceType(), email.getBounceSubType(), email.getBounceDiagnosticCode(),
+            email.getSkipReason()
+        );
+    }
+
+    private void renderEmailDetailFields(int i,
+            String sendDts, String emailAddr, String subject, Boolean internal,
+            Boolean delivered, Boolean skipped, String bounceDts,
+            Boolean opened, String openedDts, Boolean clicked, String clickedDts,
+            String deliveryDts, String reportingMta, String smtpResponse,
+            String bounceType, String bounceSubType, String bounceDiagnostic,
+            String skipReason) {
+        String internalNote = Boolean.TRUE.equals(internal) ? "   (internal copy)" : "";
+        System.out.printf("  [%d] sent %s%s%n", i, sendDts != null ? sendDts : "?", internalNote);
+        System.out.printf("      To:               %s%n", safeStr(emailAddr));
+        System.out.printf("      Subject:          %s%n", safeStr(subject));
+
+        List<String> states = new ArrayList<>();
+        if (Boolean.TRUE.equals(delivered)) states.add("DELIVERED");
+        if (Boolean.TRUE.equals(skipped))   states.add("SKIPPED");
+        if (bounceDts != null)              states.add("BOUNCED " + bounceDts);
+        if (Boolean.TRUE.equals(opened))    states.add("OPENED " + safeStr(openedDts));
+        if (Boolean.TRUE.equals(clicked))   states.add("CLICKED " + safeStr(clickedDts));
+        System.out.printf("      Status:           %s%n", states.isEmpty() ? "unknown" : String.join(", ", states));
+
+        if (deliveryDts != null)        System.out.printf("      Delivered:        %s%n", deliveryDts);
+        if (reportingMta != null)       System.out.printf("      Reporting MTA:    %s%n", reportingMta);
+        if (smtpResponse != null)       System.out.printf("      SMTP response:    %s%n", smtpResponse);
+        if (bounceType != null)         System.out.printf("      Bounce type:      %s / %s%n", bounceType, safeStr(bounceSubType));
+        if (bounceDiagnostic != null)   System.out.printf("      Diagnostic:       %s%n", bounceDiagnostic);
+        if (skipReason != null)         System.out.printf("      Skip reason:      %s%n", skipReason);
+        System.out.println();
+    }
+
+    private void renderPageViewHistory(List<OrderPageView> pageViews, String sessionReferrer, String sourceOrderId, boolean isRedirected) {
+        section("4. PAGE VIEW HISTORY (" + pageViews.size() + " views)");
+        if (isRedirected) {
+            System.out.println("  Note: this is a subscription rebill. The disputed order itself has no");
+            System.out.println("  checkout session of its own. The page views below are from the ORIGINAL");
+            System.out.println("  order that started the subscription, where the customer's intent was");
+            System.out.println("  captured during signup.");
+            System.out.println();
+            kv("Source order", sourceOrderId);
+        }
+        kv("Session referrer", sessionReferrer != null ? sessionReferrer : "(direct or unknown)");
+
+        if (pageViews.isEmpty()) {
+            System.out.println();
+            System.out.println("  No page views captured" + (isRedirected ? " for the original order." : " for this order's session."));
+            return;
+        }
+
+        subsection("Timeline");
+        for (OrderPageView pv : pageViews) {
+            String tops = pv.getTimeOnPage() == null ? "   -" : String.format("%4ds", pv.getTimeOnPage());
+            System.out.printf("  %-22s %s   %s%n", safeStr(pv.getViewDts()), tops, safeStr(pv.getUrl()));
+        }
+
+        if (pageViews.size() >= 2) {
+            try {
+                OffsetDateTime first = OffsetDateTime.parse(pageViews.get(0).getViewDts());
+                OffsetDateTime last  = OffsetDateTime.parse(pageViews.get(pageViews.size() - 1).getViewDts());
+                long elapsed = last.toEpochSecond() - first.toEpochSecond();
+                if (elapsed > 0) {
+                    long mins = elapsed / 60;
+                    long secs = elapsed % 60;
+                    System.out.println();
+                    kv("Session length", mins + "m " + secs + "s (first view to last view)");
+                }
+            } catch (DateTimeParseException | NullPointerException ignored) {
+                // unparseable timestamp; skip the elapsed calc
+            }
+        }
+
+        Set<String> uniqueUrls = new LinkedHashSet<>();
+        for (OrderPageView pv : pageViews) {
+            if (pv.getUrl() != null) uniqueUrls.add(pv.getUrl());
+        }
+        kv("Unique URLs visited", String.valueOf(uniqueUrls.size()));
+    }
+
+    private void renderAddress(String firstName, String lastName, String company,
+                                String addr1, String addr2, String city, String state,
+                                String postalCode, String countryCode) {
+        if (firstName == null && lastName == null && addr1 == null && city == null) {
+            System.out.println("  (none on file)");
+            return;
+        }
+        String name    = joinNonEmpty(" ", firstName, lastName);
+        String cityRow = ((city != null ? city : "")
+                          + (state != null ? ", " + state : "")
+                          + " " + (postalCode != null ? postalCode : "")).trim();
+        for (String line : new String[] { name, company, addr1, addr2, cityRow, countryCode }) {
+            if (line != null && !line.trim().isEmpty()) System.out.println("  " + line);
+        }
+    }
+
+    private void renderFooter() {
+        System.out.println();
+        hr('=');
+        System.out.println("  END OF EVIDENCE REPORT");
+        hr('=');
+    }
+
+    // =====================================================================
+    // Tiny formatting primitives
+    // =====================================================================
+
+    private void hr(char c) {
+        char[] chars = new char[80];
+        Arrays.fill(chars, c);
+        System.out.println(new String(chars));
+    }
+
+    private void section(String title) {
+        System.out.println();
+        hr('=');
+        System.out.println("  " + title);
+        hr('=');
+        System.out.println();
+    }
+
+    private void subsection(String title) {
+        System.out.println();
+        System.out.println("  " + title);
+        char[] dashes = new char[title.length()];
+        Arrays.fill(dashes, '-');
+        System.out.println("  " + new String(dashes));
+    }
+
+    private void kv(String label, Object value) {
+        System.out.printf("  %-22s %s%n", label + ":", value != null ? value.toString() : "");
+    }
+
+    private static String safeStr(String s) { return s != null ? s : ""; }
+
+    private static String shorten(String s, int n) {
+        if (s == null) return "";
+        return s.length() <= n ? s : s.substring(0, n - 1) + "~";
+    }
+
+    private static String joinNonEmpty(String sep, String... parts) {
+        StringBuilder sb = new StringBuilder();
+        for (String p : parts) {
+            if (p != null && !p.isEmpty()) {
+                if (sb.length() > 0) sb.append(sep);
+                sb.append(p);
+            }
+        }
+        return sb.toString();
+    }
+
+    private static double toDouble(java.math.BigDecimal bd) {
+        return bd != null ? bd.doubleValue() : 0.0;
+    }
+
+    private static String money(double amount, String currency) {
+        String sign = amount < 0 ? "-" : "";
+        return String.format("%s$%,.2f %s", sign, Math.abs(amount), currency != null ? currency : "").trim();
+    }
+
+    private static void failOp(String operation, Error error) {
+        System.err.println("ERROR in " + operation + ":");
+        System.err.println("  Developer message: " + (error.getDeveloperMessage() != null ? error.getDeveloperMessage() : ""));
+        System.err.println("  User message:      " + (error.getUserMessage()      != null ? error.getUserMessage()      : ""));
+        System.exit(1);
+    }
+}

--- a/javascript/order/getChargebackEvidence.js
+++ b/javascript/order/getChargebackEvidence.js
@@ -18,11 +18,10 @@ import { orderApi, autoOrderApi } from '../api.js';
  *   3. Page view history (the customer was on your site, navigated through
  *      pages, spent time before placing the order).
  *   4. Auto-order detection: a large fraction of chargebacks are subscription
- *      disputes. When the order is part of an auto order, this sample pulls
- *      the parent subscription, every rebill that has occurred on it, and the
- *      auto-order-level email log. For rebills specifically, the page-view
- *      lookup pivots to the ORIGINAL order (the rebill itself has no checkout
- *      session).
+ *      disputes. When the order is part of an auto order, the sample pulls
+ *      the parent subscription, every rebill, and the auto-order-level email
+ *      log. For rebills specifically, the page-view lookup pivots to the
+ *      ORIGINAL order (the rebill itself has no checkout session).
  *
  * Run:
  *   NODE_TLS_REJECT_UNAUTHORIZED=0 node order/getChargebackEvidence.js DEMO-0009104976
@@ -33,40 +32,19 @@ import { orderApi, autoOrderApi } from '../api.js';
 export async function execute() {
     const orderId = process.argv[2] || 'DEMO-0009104976';
 
-    // Listing expansions individually (rather than relying on a catch-all) keeps
-    // payload size predictable and makes it obvious what evidence each piece is
-    // providing. Add or remove based on what your dispute reason code requires.
     const orderExpansion = [
-        'billing',                  // address customer entered for billing
-        'shipping',                 // address goods shipped to
-        'payment',                  // payment method, card last four, gateway info
-        'payment.transaction',      // auth/capture/refund timeline
-        'summary',                  // totals, tax, shipping, weights
-        'items',                    // line items the customer ordered
-        'coupon',                   // discounts the customer chose to apply
-        'customer_profile',         // returning-customer signal, account history
-        'auto_order',               // detect subscription chargebacks
-        'utms',                     // entry-path UTM clicks (attribution chain)
-        'marketing',                // affiliate / source-code attribution
-        'gift',                     // gift-giving intent if applicable
-        'point_of_sale',            // POS terminal / location for retail orders
-        'channel_partner',          // channel partner data
+        'billing', 'shipping', 'payment', 'payment.transaction', 'summary',
+        'items', 'coupon', 'customer_profile', 'auto_order', 'utms',
+        'marketing', 'gift', 'point_of_sale', 'channel_partner',
     ].join(',');
 
-    const autoOrderExpansion = [
-        'items',                    // subscription line items + frequency
-        'rebill_orders',            // every rebill that has occurred
-        'logs',                     // status changes, payment attempts, cancellations
-        'management',               // self-service management state
-    ].join(',');
+    const autoOrderExpansion = ['items', 'rebill_orders', 'logs', 'management'].join(',');
 
-    // Tiny callback->promise wrapper - keeps the read flow linear below.
     const promisify = (fn) => new Promise((resolve, reject) => {
         fn((error, data /*, response */) => error ? reject(error) : resolve(data));
     });
 
     try {
-        // Order detail
         const orderResponse = await promisify(cb => orderApi.getOrder(orderId, { _expand: orderExpansion }, cb));
         if (orderResponse.error) failOp('getOrder', orderResponse.error);
         const order = orderResponse.order;
@@ -79,37 +57,36 @@ export async function execute() {
         const emails = emailsResponse.emails || [];
 
         // Auto-order chain BEFORE page views: a rebill's own page view history
-        // is empty - the customer never went through checkout for the rebill.
+        // is empty - the meaningful history lives on the original order.
         let autoOrder = null;
         let autoOrderEmails = [];
         let rebillOrders = [];
-        const autoOrderPointer = order.autoOrder; // populated by ?_expand=auto_order
-        if (autoOrderPointer && autoOrderPointer.autoOrderOid) {
-            const autoOrderOid = autoOrderPointer.autoOrderOid;
+        const autoOrderPointer = order.auto_order;
+        if (autoOrderPointer && autoOrderPointer.auto_order_oid) {
+            const autoOrderOid = autoOrderPointer.auto_order_oid;
 
             const aoResponse = await promisify(cb => autoOrderApi.getAutoOrder(autoOrderOid, { _expand: autoOrderExpansion }, cb));
             if (aoResponse.error) failOp('getAutoOrder', aoResponse.error);
-            autoOrder = aoResponse.autoOrder;
-            rebillOrders = autoOrder.rebillOrders || [];
+            autoOrder = aoResponse.auto_order;
+            rebillOrders = autoOrder.rebill_orders || [];
 
             const aoEmailsResponse = await promisify(cb => autoOrderApi.getAutoOrderEmails(autoOrderOid, cb));
             if (aoEmailsResponse.error) failOp('getAutoOrderEmails', aoEmailsResponse.error);
             autoOrderEmails = aoEmailsResponse.emails || [];
         }
 
-        // For a rebill chargeback, page views live on the ORIGINAL order.
         let pageViewOrderId = orderId;
         let pageViewIsRedirected = false;
         if (autoOrder &&
-            autoOrder.originalOrderId &&
-            autoOrder.originalOrderId.toLowerCase() !== orderId.toLowerCase()) {
-            pageViewOrderId = autoOrder.originalOrderId;
+            autoOrder.original_order_id &&
+            autoOrder.original_order_id.toLowerCase() !== orderId.toLowerCase()) {
+            pageViewOrderId = autoOrder.original_order_id;
             pageViewIsRedirected = true;
         }
 
         const pageViewResponse = await promisify(cb => orderApi.getOrderPageViewHistory(pageViewOrderId, cb));
         if (pageViewResponse.error) failOp('getOrderPageViewHistory', pageViewResponse.error);
-        const pageViews = pageViewResponse.pageViews || [];
+        const pageViews = pageViewResponse.page_views || [];
         const sessionReferrer = pageViewResponse.referrer;
 
         renderHeader(orderId);
@@ -141,22 +118,24 @@ function renderHeader(orderId) {
 function renderOrderOverview(order) {
     section('1. ORDER OVERVIEW');
 
-    kv('Placed',   order.creationDts);
-    kv('Stage',    order.currentStage);
-    kv('Currency', order.currencyCode);
-    if (order.summary) kv('Order Total', money(order.summary.total, order.currencyCode));
+    kv('Placed',   order.creation_dts);
+    kv('Stage',    order.current_stage);
+    kv('Currency', order.currency_code);
+    if (order.summary) kv('Order Total', money(moneyValue(order.summary.total), order.currency_code));
 
     subsection('Customer');
     const billing = order.billing;
     if (billing) {
-        kv('Name',  [billing.firstName, billing.lastName].filter(Boolean).join(' ').trim());
+        kv('Name',  [billing.first_name, billing.last_name].filter(Boolean).join(' ').trim());
         kv('Email', billing.email);
-        kv('Phone', billing.phone);
+        // First populated phone wins
+        kv('Phone', billing.day_phone || billing.evening_phone || billing.cell_phone);
     }
-    const cp = order.customerProfile;
-    kv('Customer Profile', cp ? `yes (oid ${cp.customerProfileOid || '?'})` : 'no (guest checkout)');
+    const cp = order.customer_profile;
+    kv('Customer Profile', cp ? `yes (oid ${cp.customer_profile_oid || '?'})` : 'no (guest checkout)');
     const marketing = order.marketing;
-    if (marketing && marketing.originalSourceCode) kv('Original Source', marketing.originalSourceCode);
+    if (marketing && marketing.advertising_source) kv('Advertising Source', marketing.advertising_source);
+    if (marketing && marketing.referral_code) kv('Referral Code', marketing.referral_code);
 
     subsection('Billing Address');
     renderAddress(billing);
@@ -166,40 +145,37 @@ function renderOrderOverview(order) {
 
     subsection('Items');
     for (const item of (order.items || [])) {
-        if (item.kitComponent) continue; // skip kit components - sub-rows of a parent kit
+        if (item.kit_component) continue; // skip kit components - sub-rows of a parent kit
         const qty  = item.quantity || 0;
-        const cost = item.cost || 0;
+        const cost = moneyValue(item.cost) || 0; // OrderItem.cost is a Currency object
         console.log(
-            '  ' + pad(shorten(item.merchantItemId || '', 12), 12) + ' ' +
+            '  ' + pad(shorten(item.merchant_item_id || '', 12), 12) + ' ' +
             pad(shorten(item.description || '', 32), 32) +
-            ` qty ${qty} @ ${money(cost, order.currencyCode)} = ${money(qty * cost, order.currencyCode)}`
+            ` qty ${qty} @ ${money(cost, order.currency_code)} = ${money(qty * cost, order.currency_code)}`
         );
     }
 
     if (order.summary) {
         console.log();
-        kv('Subtotal', money(order.summary.subtotal, order.currencyCode));
-        if (order.summary.tax !== null && order.summary.tax !== undefined)
-            kv('Tax',      money(order.summary.tax, order.currencyCode));
-        if (order.summary.shippingHandling !== null && order.summary.shippingHandling !== undefined)
-            kv('Shipping', money(order.summary.shippingHandling, order.currencyCode));
-        kv('Total',    money(order.summary.total, order.currencyCode));
+        kv('Subtotal', money(moneyValue(order.summary.subtotal), order.currency_code));
+        if (order.summary.tax)                     kv('Tax',      money(moneyValue(order.summary.tax), order.currency_code));
+        if (order.summary.shipping_handling_total) kv('Shipping', money(moneyValue(order.summary.shipping_handling_total), order.currency_code));
+        kv('Total',    money(moneyValue(order.summary.total), order.currency_code));
     }
 
     subsection('Payment');
     const payment = order.payment;
     if (payment) {
-        kv('Method', payment.paymentMethod);
-        const cc = payment.creditCard;
-        if (cc) kv('Card', `${cc.cardType || ''} ending ${cc.cardNumberTruncated || '????'}`.trim());
+        kv('Method', payment.payment_method);
+        const cc = payment.credit_card;
+        if (cc) kv('Card', `${cc.card_type || ''} ending ${cc.card_number_truncated || '????'}`.trim());
         const transactions = payment.transactions || [];
         if (transactions.length) {
             subsection('Transactions');
             for (const tx of transactions) {
                 console.log(
-                    '  ' + pad(tx.dts || '', 21) + ' ' +
-                    pad(tx.transactionType || '', 12) + ' ' +
-                    pad(money(tx.amount, order.currencyCode), 12) + ' ' +
+                    '  ' + pad(tx.transaction_timestamp || '', 21) + ' ' +
+                    pad(shorten(tx.transaction_gateway || '', 30), 30) + ' ' +
                     (tx.successful ? 'approved' : 'failed')
                 );
             }
@@ -208,14 +184,15 @@ function renderOrderOverview(order) {
 
     subsection('Marketing / Attribution');
     const utms = order.utms || [];
-    if (marketing) kv('Affiliate ID', marketing.affiliateId || '(none)');
+    // Affiliate attribution lives on OrderAffiliate (expansion=affiliate); not pulled
+    // here to keep the chargeback request light.
     if (utms.length === 0) {
         console.log('  No UTM clicks captured.');
     } else {
         const mostRecent = utms[0]; // index 0 is most recent click
-        kv('Most recent UTM source',   mostRecent.utmSource);
-        kv('Most recent UTM medium',   mostRecent.utmMedium);
-        kv('Most recent UTM campaign', mostRecent.utmCampaign);
+        kv('Most recent UTM source',   mostRecent.utm_source);
+        kv('Most recent UTM medium',   mostRecent.utm_medium);
+        kv('Most recent UTM campaign', mostRecent.utm_campaign);
         kv('UTM clicks captured', String(utms.length));
     }
 }
@@ -230,15 +207,15 @@ function renderSubscription(autoOrder, rebillOrders, currentOrderId, autoOrderEm
 
     console.log('  This order IS part of an auto order subscription.');
     console.log();
-    kv('Auto Order Code', autoOrder.autoOrderCode);
+    kv('Auto Order Code', autoOrder.auto_order_code);
     kv('Status',          autoOrder.status);
     kv('Enabled',         autoOrder.enabled ? 'yes' : 'no');
-    kv('Original Order',  autoOrder.originalOrderId);
-    kv('Next Attempt',    autoOrder.nextAttempt || '(none scheduled)');
-    if (autoOrder.canceledDts) {
-        kv('Canceled',      autoOrder.canceledDts);
-        kv('Canceled By',   autoOrder.canceledByUser || '');
-        kv('Cancel Reason', autoOrder.cancelReason || '');
+    kv('Original Order',  autoOrder.original_order_id);
+    kv('Next Attempt',    autoOrder.next_attempt || '(none scheduled)');
+    if (autoOrder.canceled_dts) {
+        kv('Canceled',      autoOrder.canceled_dts);
+        kv('Canceled By',   autoOrder.canceled_by_user || '');
+        kv('Cancel Reason', autoOrder.cancel_reason || '');
     }
     kv('Total Rebills', String(rebillOrders.length));
 
@@ -247,8 +224,8 @@ function renderSubscription(autoOrder, rebillOrders, currentOrderId, autoOrderEm
         subsection('Items in Subscription');
         for (const aoi of aoItems) {
             console.log(
-                '  ' + pad(shorten(aoi.originalItemId || '', 12), 12) + ' ' +
-                pad(shorten(aoi.originalItemId || '', 32), 32) +
+                '  ' + pad(shorten(aoi.original_item_id || '', 12), 12) + ' ' +
+                pad(shorten(aoi.original_item_id || '', 32), 32) +
                 ` frequency: ${aoi.frequency || ''}`
             );
         }
@@ -256,16 +233,16 @@ function renderSubscription(autoOrder, rebillOrders, currentOrderId, autoOrderEm
 
     if (rebillOrders.length) {
         subsection('Rebill Timeline');
-        rebillOrders.sort((a, b) => (a.creationDts || '').localeCompare(b.creationDts || ''));
+        rebillOrders.sort((a, b) => (a.creation_dts || '').localeCompare(b.creation_dts || ''));
         for (const ro of rebillOrders) {
-            const roId    = ro.orderId || '';
+            const roId    = ro.order_id || '';
             const marker  = roId.toLowerCase() === currentOrderId.toLowerCase() ? '  *** THIS ORDER' : '';
-            const roTotal = ro.summary ? money(ro.summary.total, ro.currencyCode || 'USD') : '';
+            const roTotal = ro.summary ? money(moneyValue(ro.summary.total), ro.currency_code || 'USD') : '';
             console.log(
-                '  ' + pad(ro.creationDts || '', 22) + ' ' +
+                '  ' + pad(ro.creation_dts || '', 22) + ' ' +
                 pad(roId, 22) + ' ' +
                 pad(roTotal, 10) + ' ' +
-                (ro.currentStage || '') + marker
+                (ro.current_stage || '') + marker
             );
         }
     }
@@ -290,24 +267,24 @@ function renderEmails(emails) {
 
 function renderEmailDetail(i, email) {
     const internal = email.internal ? '   (internal copy)' : '';
-    console.log(`  [${i}] sent ${email.sendDts || '?'}${internal}`);
+    console.log(`  [${i}] sent ${email.send_dts || '?'}${internal}`);
     console.log(`      To:               ${email.email || ''}`);
     console.log(`      Subject:          ${email.subject || ''}`);
 
     const states = [];
     if (email.delivered)               states.push('DELIVERED');
     if (email.skipped)                 states.push('SKIPPED');
-    if (email.bounceDts)               states.push(`BOUNCED ${email.bounceDts}`);
-    if (email.opened)                  states.push(`OPENED ${email.openedDts || ''}`);
-    if (email.clicked)                 states.push(`CLICKED ${email.clickedDts || ''}`);
+    if (email.bounce_dts)              states.push(`BOUNCED ${email.bounce_dts}`);
+    if (email.opened)                  states.push(`OPENED ${email.opened_dts || ''}`);
+    if (email.clicked)                 states.push(`CLICKED ${email.clicked_dts || ''}`);
     console.log(`      Status:           ${states.length ? states.join(', ') : 'unknown'}`);
 
-    if (email.deliveryDts)           console.log(`      Delivered:        ${email.deliveryDts}`);
-    if (email.reportingMta)          console.log(`      Reporting MTA:    ${email.reportingMta}`);
-    if (email.smtpResponse)          console.log(`      SMTP response:    ${email.smtpResponse}`);
-    if (email.bounceType)            console.log(`      Bounce type:      ${email.bounceType} / ${email.bounceSubType || ''}`);
-    if (email.bounceDiagnosticCode)  console.log(`      Diagnostic:       ${email.bounceDiagnosticCode}`);
-    if (email.skipReason)            console.log(`      Skip reason:      ${email.skipReason}`);
+    if (email.delivery_dts)            console.log(`      Delivered:        ${email.delivery_dts}`);
+    if (email.reporting_mta)           console.log(`      Reporting MTA:    ${email.reporting_mta}`);
+    if (email.smtp_response)           console.log(`      SMTP response:    ${email.smtp_response}`);
+    if (email.bounce_type)             console.log(`      Bounce type:      ${email.bounce_type} / ${email.bounce_sub_type || ''}`);
+    if (email.bounce_diagnostic_code)  console.log(`      Diagnostic:       ${email.bounce_diagnostic_code}`);
+    if (email.skip_reason)             console.log(`      Skip reason:      ${email.skip_reason}`);
     console.log();
 }
 
@@ -331,14 +308,14 @@ function renderPageViewHistory(pageViews, sessionReferrer, sourceOrderId, isRedi
 
     subsection('Timeline');
     for (const pv of pageViews) {
-        const top  = pv.timeOnPage;
+        const top  = pv.time_on_page;
         const tops = top === null || top === undefined ? '   -' : String(top).padStart(4, ' ') + 's';
-        console.log(`  ${pad(pv.viewDts || '', 22)} ${tops}   ${pv.url || ''}`);
+        console.log(`  ${pad(pv.view_dts || '', 22)} ${tops}   ${pv.url || ''}`);
     }
 
     if (pageViews.length >= 2) {
-        const first = Date.parse(pageViews[0].viewDts || '');
-        const last  = Date.parse(pageViews[pageViews.length - 1].viewDts || '');
+        const first = Date.parse(pageViews[0].view_dts || '');
+        const last  = Date.parse(pageViews[pageViews.length - 1].view_dts || '');
         if (!isNaN(first) && !isNaN(last) && last > first) {
             const elapsed = Math.floor((last - first) / 1000);
             const mins = Math.floor(elapsed / 60);
@@ -354,13 +331,13 @@ function renderPageViewHistory(pageViews, sessionReferrer, sourceOrderId, isRedi
 
 function renderAddress(address) {
     if (!address) { console.log('  (none on file)'); return; }
-    const name    = [address.firstName, address.lastName].filter(Boolean).join(' ').trim();
+    const name    = [address.first_name, address.last_name].filter(Boolean).join(' ').trim();
     const cityRow = (
         (address.city || '') +
-        (address.state ? `, ${address.state}` : '') +
-        ' ' + (address.postalCode || '')
+        (address.state_region ? `, ${address.state_region}` : '') +
+        ' ' + (address.postal_code || '')
     ).trim();
-    [name, address.company, address.address1, address.address2, cityRow, address.countryCode]
+    [name, address.company, address.address1, address.address2, cityRow, address.country_code]
         .filter(line => line && line.trim().length > 0)
         .forEach(line => console.log(`  ${line}`));
 }
@@ -383,6 +360,13 @@ function kv(label, value, width = 22) {
 }
 function pad(s, n) { s = s == null ? '' : String(s); return s.length >= n ? s : s + ' '.repeat(n - s.length); }
 function shorten(s, n) { s = s == null ? '' : String(s); return s.length <= n ? s : s.substring(0, n - 1) + '~'; }
+
+// SDK money fields are Currency objects, not raw numbers. Pull the localized
+// value off; null-safe for missing/optional fields.
+function moneyValue(currency) {
+    if (currency === null || currency === undefined) return undefined;
+    return currency.localized;
+}
 function money(amount, currency) {
     if (amount === null || amount === undefined) return '';
     const sign = amount < 0 ? '-' : '';
@@ -391,7 +375,7 @@ function money(amount, currency) {
 
 function failOp(operation, error) {
     console.error(`ERROR in ${operation}:`);
-    console.error(`  Developer message: ${error.developer_message || error.developerMessage || ''}`);
-    console.error(`  User message:      ${error.user_message      || error.userMessage      || ''}`);
+    console.error(`  Developer message: ${error.developer_message || ''}`);
+    console.error(`  User message:      ${error.user_message      || ''}`);
     process.exit(1);
 }

--- a/javascript/order/getChargebackEvidence.js
+++ b/javascript/order/getChargebackEvidence.js
@@ -1,0 +1,397 @@
+import { orderApi, autoOrderApi } from '../api.js';
+
+/**
+ * getChargebackEvidence
+ *
+ * Pulls everything from UltraCart that is useful when fighting a chargeback
+ * dispute and prints a formatted evidence report. Designed as a starting point
+ * for building the actual evidence packet you submit to the card processor.
+ *
+ * What this sample demonstrates:
+ *   1. Order detail with the SPECIFIC expansions a chargeback case relies on.
+ *      Notice we list every expansion explicitly - no shortcuts. Listing them
+ *      individually keeps your payload small and forces you to think about
+ *      what evidence each one represents.
+ *   2. Email delivery records via the dedicated /emails endpoint (not via
+ *      expansion). Use the dedicated endpoint for chargeback work - it is the
+ *      canonical full-fidelity source for SES delivery events on every order.
+ *   3. Page view history (the customer was on your site, navigated through
+ *      pages, spent time before placing the order).
+ *   4. Auto-order detection: a large fraction of chargebacks are subscription
+ *      disputes. When the order is part of an auto order, this sample pulls
+ *      the parent subscription, every rebill that has occurred on it, and the
+ *      auto-order-level email log. For rebills specifically, the page-view
+ *      lookup pivots to the ORIGINAL order (the rebill itself has no checkout
+ *      session).
+ *
+ * Run:
+ *   NODE_TLS_REJECT_UNAUTHORIZED=0 node order/getChargebackEvidence.js DEMO-0009104976
+ *
+ * Requires the May 2026 SDK build with getOrderEmails,
+ * getOrderPageViewHistory, and getAutoOrderEmails.
+ */
+export async function execute() {
+    const orderId = process.argv[2] || 'DEMO-0009104976';
+
+    // Listing expansions individually (rather than relying on a catch-all) keeps
+    // payload size predictable and makes it obvious what evidence each piece is
+    // providing. Add or remove based on what your dispute reason code requires.
+    const orderExpansion = [
+        'billing',                  // address customer entered for billing
+        'shipping',                 // address goods shipped to
+        'payment',                  // payment method, card last four, gateway info
+        'payment.transaction',      // auth/capture/refund timeline
+        'summary',                  // totals, tax, shipping, weights
+        'items',                    // line items the customer ordered
+        'coupon',                   // discounts the customer chose to apply
+        'customer_profile',         // returning-customer signal, account history
+        'auto_order',               // detect subscription chargebacks
+        'utms',                     // entry-path UTM clicks (attribution chain)
+        'marketing',                // affiliate / source-code attribution
+        'gift',                     // gift-giving intent if applicable
+        'point_of_sale',            // POS terminal / location for retail orders
+        'channel_partner',          // channel partner data
+    ].join(',');
+
+    const autoOrderExpansion = [
+        'items',                    // subscription line items + frequency
+        'rebill_orders',            // every rebill that has occurred
+        'logs',                     // status changes, payment attempts, cancellations
+        'management',               // self-service management state
+    ].join(',');
+
+    // Tiny callback->promise wrapper - keeps the read flow linear below.
+    const promisify = (fn) => new Promise((resolve, reject) => {
+        fn((error, data /*, response */) => error ? reject(error) : resolve(data));
+    });
+
+    try {
+        // Order detail
+        const orderResponse = await promisify(cb => orderApi.getOrder(orderId, { _expand: orderExpansion }, cb));
+        if (orderResponse.error) failOp('getOrder', orderResponse.error);
+        const order = orderResponse.order;
+
+        // Use the dedicated /emails endpoint rather than _expand=emails. The
+        // dedicated endpoint is the canonical full-fidelity source for SES
+        // delivery events.
+        const emailsResponse = await promisify(cb => orderApi.getOrderEmails(orderId, cb));
+        if (emailsResponse.error) failOp('getOrderEmails', emailsResponse.error);
+        const emails = emailsResponse.emails || [];
+
+        // Auto-order chain BEFORE page views: a rebill's own page view history
+        // is empty - the customer never went through checkout for the rebill.
+        let autoOrder = null;
+        let autoOrderEmails = [];
+        let rebillOrders = [];
+        const autoOrderPointer = order.autoOrder; // populated by ?_expand=auto_order
+        if (autoOrderPointer && autoOrderPointer.autoOrderOid) {
+            const autoOrderOid = autoOrderPointer.autoOrderOid;
+
+            const aoResponse = await promisify(cb => autoOrderApi.getAutoOrder(autoOrderOid, { _expand: autoOrderExpansion }, cb));
+            if (aoResponse.error) failOp('getAutoOrder', aoResponse.error);
+            autoOrder = aoResponse.autoOrder;
+            rebillOrders = autoOrder.rebillOrders || [];
+
+            const aoEmailsResponse = await promisify(cb => autoOrderApi.getAutoOrderEmails(autoOrderOid, cb));
+            if (aoEmailsResponse.error) failOp('getAutoOrderEmails', aoEmailsResponse.error);
+            autoOrderEmails = aoEmailsResponse.emails || [];
+        }
+
+        // For a rebill chargeback, page views live on the ORIGINAL order.
+        let pageViewOrderId = orderId;
+        let pageViewIsRedirected = false;
+        if (autoOrder &&
+            autoOrder.originalOrderId &&
+            autoOrder.originalOrderId.toLowerCase() !== orderId.toLowerCase()) {
+            pageViewOrderId = autoOrder.originalOrderId;
+            pageViewIsRedirected = true;
+        }
+
+        const pageViewResponse = await promisify(cb => orderApi.getOrderPageViewHistory(pageViewOrderId, cb));
+        if (pageViewResponse.error) failOp('getOrderPageViewHistory', pageViewResponse.error);
+        const pageViews = pageViewResponse.pageViews || [];
+        const sessionReferrer = pageViewResponse.referrer;
+
+        renderHeader(orderId);
+        renderOrderOverview(order);
+        renderSubscription(autoOrder, rebillOrders, orderId, autoOrderEmails);
+        renderEmails(emails);
+        renderPageViewHistory(pageViews, sessionReferrer, pageViewOrderId, pageViewIsRedirected);
+        renderFooter();
+    } catch (error) {
+        console.error('Error gathering chargeback evidence:', error);
+        process.exit(1);
+    }
+}
+
+// =====================================================================
+// Render helpers
+// =====================================================================
+
+function renderHeader(orderId) {
+    hr('=');
+    console.log('  CHARGEBACK EVIDENCE REPORT');
+    console.log('  UltraCart REST API v2');
+    hr('=');
+    console.log();
+    kv('Order ID',  orderId);
+    kv('Generated', new Date().toISOString());
+}
+
+function renderOrderOverview(order) {
+    section('1. ORDER OVERVIEW');
+
+    kv('Placed',   order.creationDts);
+    kv('Stage',    order.currentStage);
+    kv('Currency', order.currencyCode);
+    if (order.summary) kv('Order Total', money(order.summary.total, order.currencyCode));
+
+    subsection('Customer');
+    const billing = order.billing;
+    if (billing) {
+        kv('Name',  [billing.firstName, billing.lastName].filter(Boolean).join(' ').trim());
+        kv('Email', billing.email);
+        kv('Phone', billing.phone);
+    }
+    const cp = order.customerProfile;
+    kv('Customer Profile', cp ? `yes (oid ${cp.customerProfileOid || '?'})` : 'no (guest checkout)');
+    const marketing = order.marketing;
+    if (marketing && marketing.originalSourceCode) kv('Original Source', marketing.originalSourceCode);
+
+    subsection('Billing Address');
+    renderAddress(billing);
+
+    subsection('Shipping Address');
+    renderAddress(order.shipping);
+
+    subsection('Items');
+    for (const item of (order.items || [])) {
+        if (item.kitComponent) continue; // skip kit components - sub-rows of a parent kit
+        const qty  = item.quantity || 0;
+        const cost = item.cost || 0;
+        console.log(
+            '  ' + pad(shorten(item.merchantItemId || '', 12), 12) + ' ' +
+            pad(shorten(item.description || '', 32), 32) +
+            ` qty ${qty} @ ${money(cost, order.currencyCode)} = ${money(qty * cost, order.currencyCode)}`
+        );
+    }
+
+    if (order.summary) {
+        console.log();
+        kv('Subtotal', money(order.summary.subtotal, order.currencyCode));
+        if (order.summary.tax !== null && order.summary.tax !== undefined)
+            kv('Tax',      money(order.summary.tax, order.currencyCode));
+        if (order.summary.shippingHandling !== null && order.summary.shippingHandling !== undefined)
+            kv('Shipping', money(order.summary.shippingHandling, order.currencyCode));
+        kv('Total',    money(order.summary.total, order.currencyCode));
+    }
+
+    subsection('Payment');
+    const payment = order.payment;
+    if (payment) {
+        kv('Method', payment.paymentMethod);
+        const cc = payment.creditCard;
+        if (cc) kv('Card', `${cc.cardType || ''} ending ${cc.cardNumberTruncated || '????'}`.trim());
+        const transactions = payment.transactions || [];
+        if (transactions.length) {
+            subsection('Transactions');
+            for (const tx of transactions) {
+                console.log(
+                    '  ' + pad(tx.dts || '', 21) + ' ' +
+                    pad(tx.transactionType || '', 12) + ' ' +
+                    pad(money(tx.amount, order.currencyCode), 12) + ' ' +
+                    (tx.successful ? 'approved' : 'failed')
+                );
+            }
+        }
+    }
+
+    subsection('Marketing / Attribution');
+    const utms = order.utms || [];
+    if (marketing) kv('Affiliate ID', marketing.affiliateId || '(none)');
+    if (utms.length === 0) {
+        console.log('  No UTM clicks captured.');
+    } else {
+        const mostRecent = utms[0]; // index 0 is most recent click
+        kv('Most recent UTM source',   mostRecent.utmSource);
+        kv('Most recent UTM medium',   mostRecent.utmMedium);
+        kv('Most recent UTM campaign', mostRecent.utmCampaign);
+        kv('UTM clicks captured', String(utms.length));
+    }
+}
+
+function renderSubscription(autoOrder, rebillOrders, currentOrderId, autoOrderEmails) {
+    section('2. SUBSCRIPTION DETAILS');
+
+    if (!autoOrder) {
+        console.log('  This order is NOT part of an auto order subscription.');
+        return;
+    }
+
+    console.log('  This order IS part of an auto order subscription.');
+    console.log();
+    kv('Auto Order Code', autoOrder.autoOrderCode);
+    kv('Status',          autoOrder.status);
+    kv('Enabled',         autoOrder.enabled ? 'yes' : 'no');
+    kv('Original Order',  autoOrder.originalOrderId);
+    kv('Next Attempt',    autoOrder.nextAttempt || '(none scheduled)');
+    if (autoOrder.canceledDts) {
+        kv('Canceled',      autoOrder.canceledDts);
+        kv('Canceled By',   autoOrder.canceledByUser || '');
+        kv('Cancel Reason', autoOrder.cancelReason || '');
+    }
+    kv('Total Rebills', String(rebillOrders.length));
+
+    const aoItems = autoOrder.items || [];
+    if (aoItems.length) {
+        subsection('Items in Subscription');
+        for (const aoi of aoItems) {
+            console.log(
+                '  ' + pad(shorten(aoi.originalItemId || '', 12), 12) + ' ' +
+                pad(shorten(aoi.originalItemId || '', 32), 32) +
+                ` frequency: ${aoi.frequency || ''}`
+            );
+        }
+    }
+
+    if (rebillOrders.length) {
+        subsection('Rebill Timeline');
+        rebillOrders.sort((a, b) => (a.creationDts || '').localeCompare(b.creationDts || ''));
+        for (const ro of rebillOrders) {
+            const roId    = ro.orderId || '';
+            const marker  = roId.toLowerCase() === currentOrderId.toLowerCase() ? '  *** THIS ORDER' : '';
+            const roTotal = ro.summary ? money(ro.summary.total, ro.currencyCode || 'USD') : '';
+            console.log(
+                '  ' + pad(ro.creationDts || '', 22) + ' ' +
+                pad(roId, 22) + ' ' +
+                pad(roTotal, 10) + ' ' +
+                (ro.currentStage || '') + marker
+            );
+        }
+    }
+
+    if (autoOrderEmails.length) {
+        subsection(`Subscription-Level Emails (${autoOrderEmails.length})`);
+        autoOrderEmails.forEach((email, i) => renderEmailDetail(i + 1, email));
+    } else {
+        subsection('Subscription-Level Emails');
+        console.log('  No subscription-level emails on record.');
+    }
+}
+
+function renderEmails(emails) {
+    section(`3. EMAIL DELIVERY (${emails.length} messages)`);
+    if (emails.length === 0) {
+        console.log('  No email delivery records on file for this order.');
+        return;
+    }
+    emails.forEach((email, i) => renderEmailDetail(i + 1, email));
+}
+
+function renderEmailDetail(i, email) {
+    const internal = email.internal ? '   (internal copy)' : '';
+    console.log(`  [${i}] sent ${email.sendDts || '?'}${internal}`);
+    console.log(`      To:               ${email.email || ''}`);
+    console.log(`      Subject:          ${email.subject || ''}`);
+
+    const states = [];
+    if (email.delivered)               states.push('DELIVERED');
+    if (email.skipped)                 states.push('SKIPPED');
+    if (email.bounceDts)               states.push(`BOUNCED ${email.bounceDts}`);
+    if (email.opened)                  states.push(`OPENED ${email.openedDts || ''}`);
+    if (email.clicked)                 states.push(`CLICKED ${email.clickedDts || ''}`);
+    console.log(`      Status:           ${states.length ? states.join(', ') : 'unknown'}`);
+
+    if (email.deliveryDts)           console.log(`      Delivered:        ${email.deliveryDts}`);
+    if (email.reportingMta)          console.log(`      Reporting MTA:    ${email.reportingMta}`);
+    if (email.smtpResponse)          console.log(`      SMTP response:    ${email.smtpResponse}`);
+    if (email.bounceType)            console.log(`      Bounce type:      ${email.bounceType} / ${email.bounceSubType || ''}`);
+    if (email.bounceDiagnosticCode)  console.log(`      Diagnostic:       ${email.bounceDiagnosticCode}`);
+    if (email.skipReason)            console.log(`      Skip reason:      ${email.skipReason}`);
+    console.log();
+}
+
+function renderPageViewHistory(pageViews, sessionReferrer, sourceOrderId, isRedirected) {
+    section(`4. PAGE VIEW HISTORY (${pageViews.length} views)`);
+    if (isRedirected) {
+        console.log("  Note: this is a subscription rebill. The disputed order itself has no");
+        console.log("  checkout session of its own. The page views below are from the ORIGINAL");
+        console.log("  order that started the subscription, where the customer's intent was");
+        console.log("  captured during signup.");
+        console.log();
+        kv('Source order', sourceOrderId);
+    }
+    kv('Session referrer', sessionReferrer || '(direct or unknown)');
+
+    if (pageViews.length === 0) {
+        console.log();
+        console.log(`  No page views captured${isRedirected ? ' for the original order.' : " for this order's session."}`);
+        return;
+    }
+
+    subsection('Timeline');
+    for (const pv of pageViews) {
+        const top  = pv.timeOnPage;
+        const tops = top === null || top === undefined ? '   -' : String(top).padStart(4, ' ') + 's';
+        console.log(`  ${pad(pv.viewDts || '', 22)} ${tops}   ${pv.url || ''}`);
+    }
+
+    if (pageViews.length >= 2) {
+        const first = Date.parse(pageViews[0].viewDts || '');
+        const last  = Date.parse(pageViews[pageViews.length - 1].viewDts || '');
+        if (!isNaN(first) && !isNaN(last) && last > first) {
+            const elapsed = Math.floor((last - first) / 1000);
+            const mins = Math.floor(elapsed / 60);
+            const secs = elapsed % 60;
+            console.log();
+            kv('Session length', `${mins}m ${secs}s (first view to last view)`);
+        }
+    }
+
+    const uniqueUrls = new Set(pageViews.map(pv => pv.url).filter(Boolean));
+    kv('Unique URLs visited', String(uniqueUrls.size));
+}
+
+function renderAddress(address) {
+    if (!address) { console.log('  (none on file)'); return; }
+    const name    = [address.firstName, address.lastName].filter(Boolean).join(' ').trim();
+    const cityRow = (
+        (address.city || '') +
+        (address.state ? `, ${address.state}` : '') +
+        ' ' + (address.postalCode || '')
+    ).trim();
+    [name, address.company, address.address1, address.address2, cityRow, address.countryCode]
+        .filter(line => line && line.trim().length > 0)
+        .forEach(line => console.log(`  ${line}`));
+}
+
+function renderFooter() {
+    console.log();
+    hr('=');
+    console.log('  END OF EVIDENCE REPORT');
+    hr('=');
+}
+
+// =====================================================================
+// Tiny formatting primitives
+// =====================================================================
+function hr(char) { console.log(char.repeat(80)); }
+function section(title)    { console.log(); hr('='); console.log(`  ${title}`); hr('='); console.log(); }
+function subsection(title) { console.log(); console.log(`  ${title}`); console.log('  ' + '-'.repeat(title.length)); }
+function kv(label, value, width = 22) {
+    console.log(`  ${(label + ':').padEnd(width)} ${value === null || value === undefined ? '' : value}`);
+}
+function pad(s, n) { s = s == null ? '' : String(s); return s.length >= n ? s : s + ' '.repeat(n - s.length); }
+function shorten(s, n) { s = s == null ? '' : String(s); return s.length <= n ? s : s.substring(0, n - 1) + '~'; }
+function money(amount, currency) {
+    if (amount === null || amount === undefined) return '';
+    const sign = amount < 0 ? '-' : '';
+    return `${sign}$${Math.abs(amount).toFixed(2)} ${currency || ''}`.trim();
+}
+
+function failOp(operation, error) {
+    console.error(`ERROR in ${operation}:`);
+    console.error(`  Developer message: ${error.developer_message || error.developerMessage || ''}`);
+    console.error(`  User message:      ${error.user_message      || error.userMessage      || ''}`);
+    process.exit(1);
+}

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "luxon": "3.2.1",
         "ssl-root-cas": "^1.2.3",
-        "ultra_cart_rest_api_v2": "^4.1.15"
+        "ultra_cart_rest_api_v2": "^4.1.88"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1252,9 +1252,10 @@
       }
     },
     "node_modules/ultra_cart_rest_api_v2": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.15.tgz",
-      "integrity": "sha512-BAIqUydsQ+V2OQXu6+BphCF663HtIYbMeub/yP7HGgUu2e5wXoorHdK3hSRq7K1YtZ6aVUFwyunN8ICVPGr5Kg==",
+      "version": "4.1.88",
+      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.88.tgz",
+      "integrity": "sha512-B/hEDuVyfNWnU511f7HyyxIrFBQjn4Y9CMXYkBDC3lZpY/WuQCxWUTBJSDWfLsbPvjGO5ekHfl04Ntwz0Uqm/A==",
+      "license": "Unlicense",
       "dependencies": {
         "@babel/cli": "^7.0.0",
         "superagent": "^5.3.0"
@@ -2201,9 +2202,9 @@
       }
     },
     "ultra_cart_rest_api_v2": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.15.tgz",
-      "integrity": "sha512-BAIqUydsQ+V2OQXu6+BphCF663HtIYbMeub/yP7HGgUu2e5wXoorHdK3hSRq7K1YtZ6aVUFwyunN8ICVPGr5Kg==",
+      "version": "4.1.88",
+      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.88.tgz",
+      "integrity": "sha512-B/hEDuVyfNWnU511f7HyyxIrFBQjn4Y9CMXYkBDC3lZpY/WuQCxWUTBJSDWfLsbPvjGO5ekHfl04Ntwz0Uqm/A==",
       "requires": {
         "@babel/cli": "^7.0.0",
         "superagent": "^5.3.0"

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "luxon": "3.2.1",
     "ssl-root-cas": "^1.2.3",
-    "ultra_cart_rest_api_v2": "^4.1.15"
+    "ultra_cart_rest_api_v2": "^4.1.88"
   }
 }

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "ultracart/rest_api_v2_sdk_php": "4.1.15"
+    "ultracart/rest_api_v2_sdk_php": "4.1.88"
   },
   "config": {
     "discard-changes" : true

--- a/php/order/getChargebackEvidence.php
+++ b/php/order/getChargebackEvidence.php
@@ -95,17 +95,13 @@ if ($emails_response->getError() !== null) {
 }
 $emails = $emails_response->getEmails() ?? [];
 
-$page_view_response = $order_api->getOrderPageViewHistory($order_id);
-if ($page_view_response->getError() !== null) {
-    fail('getOrderPageViewHistory', $page_view_response->getError());
-}
-$page_views        = $page_view_response->getPageViews() ?? [];
-$session_referrer  = $page_view_response->getReferrer();
-
-// Auto-order chain (if applicable)
-$auto_order        = null;
-$auto_order_emails = [];
-$rebill_orders     = [];
+// Auto-order chain (if applicable). Resolve this BEFORE pulling page views
+// because a rebill's own page view history is empty - the customer never
+// went through checkout for the rebill, so the meaningful history lives
+// on the original order that started the subscription.
+$auto_order         = null;
+$auto_order_emails  = [];
+$rebill_orders      = [];
 $auto_order_pointer = $order->getAutoOrder();   // populated by ?_expand=auto_order
 if ($auto_order_pointer !== null && $auto_order_pointer->getAutoOrderOid() !== null) {
     $auto_order_oid = $auto_order_pointer->getAutoOrderOid();
@@ -124,6 +120,26 @@ if ($auto_order_pointer !== null && $auto_order_pointer->getAutoOrderOid() !== n
     $auto_order_emails = $ao_emails_response->getEmails() ?? [];
 }
 
+// For a rebill chargeback, the page view history that matters is the one
+// from the ORIGINAL order's checkout session. Rebills are charged
+// automatically; the customer's intent and journey were captured at signup.
+$page_view_order_id     = $order_id;
+$page_view_is_redirected = false;
+if ($auto_order !== null) {
+    $original_order_id = $auto_order->getOriginalOrderId();
+    if ($original_order_id !== null && strcasecmp($original_order_id, $order_id) !== 0) {
+        $page_view_order_id      = $original_order_id;
+        $page_view_is_redirected = true;
+    }
+}
+
+$page_view_response = $order_api->getOrderPageViewHistory($page_view_order_id);
+if ($page_view_response->getError() !== null) {
+    fail('getOrderPageViewHistory', $page_view_response->getError());
+}
+$page_views       = $page_view_response->getPageViews() ?? [];
+$session_referrer = $page_view_response->getReferrer();
+
 // --------------------------------------------------------------------
 // Render the report
 // --------------------------------------------------------------------
@@ -134,7 +150,7 @@ renderHeader($order_id);
 renderOrderOverview($order);
 renderSubscription($auto_order, $rebill_orders, $order_id, $auto_order_emails);
 renderEmails($emails);
-renderPageViewHistory($page_views, $session_referrer);
+renderPageViewHistory($page_views, $session_referrer, $page_view_order_id, $page_view_is_redirected);
 renderFooter();
 
 if (!$is_cli) echo '</pre></body></html>';
@@ -389,13 +405,20 @@ function renderEmailDetail(int $i, $email): void {
     echo "\n";
 }
 
-function renderPageViewHistory(array $page_views, ?string $session_referrer): void {
+function renderPageViewHistory(array $page_views, ?string $session_referrer, string $source_order_id, bool $is_redirected): void {
     section('4. PAGE VIEW HISTORY (' . count($page_views) . ' views)');
 
+    if ($is_redirected) {
+        echo "  Note: this is a subscription rebill. The disputed order itself has no\n";
+        echo "  checkout session of its own. The page views below are from the ORIGINAL\n";
+        echo "  order that started the subscription, where the customer's intent was\n";
+        echo "  captured during signup.\n\n";
+        kv('Source order',     $source_order_id);
+    }
     kv('Session referrer', $session_referrer ?? '(direct or unknown)');
 
     if (empty($page_views)) {
-        echo "\n  No page views captured for this order's session.\n";
+        echo "\n  No page views captured" . ($is_redirected ? ' for the original order.' : " for this order's session.") . "\n";
         echo "\n";
         return;
     }

--- a/php/order/getChargebackEvidence.php
+++ b/php/order/getChargebackEvidence.php
@@ -174,7 +174,7 @@ function renderHeader(string $order_id): void {
 function renderOrderOverview($order): void {
     section('1. ORDER OVERVIEW');
 
-    kv('Placed',       $order->getCreationDate());
+    kv('Placed',       $order->getCreationDts());
     kv('Stage',        $order->getCurrentStage());
     kv('Currency',     $order->getCurrencyCode());
 
@@ -304,7 +304,7 @@ function renderSubscription($auto_order, array $rebill_orders, string $current_o
     kv('Next Attempt',        $auto_order->getNextAttempt() ?? '(none scheduled)');
     if ($auto_order->getCanceledDts() !== null) {
         kv('Canceled',          $auto_order->getCanceledDts());
-        kv('Canceled By',       $auto_order->getCancelledByUser() ?? '');
+        kv('Canceled By',       $auto_order->getCanceledByUser() ?? '');
         kv('Cancel Reason',     $auto_order->getCancelReason() ?? '');
     }
     kv('Total Rebills',       (string) count($rebill_orders));
@@ -328,7 +328,7 @@ function renderSubscription($auto_order, array $rebill_orders, string $current_o
         subsection('Rebill Timeline');
         // Sort by creation date ascending so the earliest rebill is at the top.
         usort($rebill_orders, function ($a, $b) {
-            return strcmp($a->getCreationDate() ?? '', $b->getCreationDate() ?? '');
+            return strcmp($a->getCreationDts() ?? '', $b->getCreationDts() ?? '');
         });
         foreach ($rebill_orders as $ro) {
             $ro_id     = $ro->getOrderId() ?? '';
@@ -339,7 +339,7 @@ function renderSubscription($auto_order, array $rebill_orders, string $current_o
                 : '';
             echo sprintf(
                 "  %-22s %-22s %-10s %s%s\n",
-                $ro->getCreationDate() ?? '',
+                $ro->getCreationDts() ?? '',
                 $ro_id,
                 $ro_total,
                 $ro->getCurrentStage() ?? '',

--- a/php/order/getChargebackEvidence.php
+++ b/php/order/getChargebackEvidence.php
@@ -1,0 +1,504 @@
+<?php
+/*
+ * getChargebackEvidence.php
+ *
+ * Pulls everything from UltraCart that is useful when fighting a chargeback
+ * dispute and prints a formatted evidence report. Designed as a starting point
+ * for building the actual evidence packet you submit to the card processor.
+ *
+ * What this sample demonstrates:
+ *   1. Order detail with the SPECIFIC expansions a chargeback case relies on.
+ *      Notice we list every expansion explicitly - no shortcuts. Listing them
+ *      individually keeps your payload small and forces you to think about
+ *      what evidence each one represents.
+ *   2. Email delivery records (the customer was notified, when, by which path,
+ *      whether they opened/bounced/clicked).
+ *   3. Page view history (the customer was on your site, navigated through
+ *      pages, spent time before placing the order).
+ *   4. Auto-order detection: a large fraction of chargebacks are subscription
+ *      disputes ("I never authorized this rebill"). When the order is part of
+ *      an auto order, this sample pulls the parent subscription, every rebill
+ *      that has occurred on it, and the auto-order-level email log so you can
+ *      show the rebill schedule was disclosed and notified.
+ *
+ * Usage:
+ *   php order/getChargebackEvidence.php DEMO-0009104976
+ *
+ *   Or pass nothing to use the hard-coded default.
+ *
+ * Output:
+ *   A plain-text report. Run from CLI to read it directly; load in a browser
+ *   to view it inside <pre> tags.
+ *
+ * SDK version requirements:
+ *   This sample calls three endpoint methods that landed in the May 2026 API
+ *   release: getOrderEmails, getOrderPageViewHistory, and getAutoOrderEmails.
+ *   Run `composer update ultracart/rest_api_v2_sdk_php` to get a build that
+ *   includes them before running the sample.
+ */
+
+ini_set('display_errors', 1);
+
+use ultracart\v2\api\OrderApi;
+use ultracart\v2\api\AutoOrderApi;
+
+require_once '../vendor/autoload.php';
+require_once '../constants.php';
+
+// --------------------------------------------------------------------
+// Configuration
+// --------------------------------------------------------------------
+$order_id = $argv[1] ?? 'DEMO-0009104976';
+
+$order_api      = OrderApi::usingApiKey(Constants::API_KEY, false, false);
+$auto_order_api = AutoOrderApi::usingApiKey(Constants::API_KEY, false, false);
+
+// Listing expansions individually (rather than relying on a catch-all) keeps
+// payload size predictable and makes it obvious what evidence each piece is
+// providing. Add or remove based on what your dispute reason code requires.
+$order_expansion = implode(',', [
+    'billing',                 // address customer entered for billing
+    'shipping',                // address goods shipped to
+    'payment',                 // payment method, card last four, gateway info
+    'payment.transaction',     // auth/capture/refund timeline
+    'summary',                 // totals, tax, shipping, weights
+    'items',                   // line items the customer ordered
+    'coupon',                  // discounts the customer chose to apply
+    'customer_profile',        // returning-customer signal, account history
+    'auto_order',              // detect subscription chargebacks
+    'utms',                    // entry-path UTM clicks (attribution chain)
+    'marketing',               // affiliate / source-code attribution
+    'gift',                    // gift-giving intent if applicable
+    'point_of_sale',           // POS terminal / location for retail orders
+    'channel_partner',         // channel partner data (Amazon, eBay, etc.)
+]);
+
+$auto_order_expansion = implode(',', [
+    'items',                   // subscription line items + frequency
+    'rebill_orders',           // every rebill that has occurred
+    'logs',                    // status changes, payment attempts, cancellations
+    'management',              // self-service management state
+]);
+
+// --------------------------------------------------------------------
+// Pull the data
+// --------------------------------------------------------------------
+$order_response = $order_api->getOrder($order_id, $order_expansion);
+if ($order_response->getError() !== null) {
+    fail('getOrder', $order_response->getError());
+}
+$order = $order_response->getOrder();
+
+$emails_response = $order_api->getOrderEmails($order_id);
+if ($emails_response->getError() !== null) {
+    fail('getOrderEmails', $emails_response->getError());
+}
+$emails = $emails_response->getEmails() ?? [];
+
+$page_view_response = $order_api->getOrderPageViewHistory($order_id);
+if ($page_view_response->getError() !== null) {
+    fail('getOrderPageViewHistory', $page_view_response->getError());
+}
+$page_views        = $page_view_response->getPageViews() ?? [];
+$session_referrer  = $page_view_response->getReferrer();
+
+// Auto-order chain (if applicable)
+$auto_order        = null;
+$auto_order_emails = [];
+$rebill_orders     = [];
+$auto_order_pointer = $order->getAutoOrder();   // populated by ?_expand=auto_order
+if ($auto_order_pointer !== null && $auto_order_pointer->getAutoOrderOid() !== null) {
+    $auto_order_oid = $auto_order_pointer->getAutoOrderOid();
+
+    $ao_response = $auto_order_api->getAutoOrder($auto_order_oid, $auto_order_expansion);
+    if ($ao_response->getError() !== null) {
+        fail('getAutoOrder', $ao_response->getError());
+    }
+    $auto_order    = $ao_response->getAutoOrder();
+    $rebill_orders = $auto_order->getRebillOrders() ?? [];
+
+    $ao_emails_response = $auto_order_api->getAutoOrderEmails($auto_order_oid);
+    if ($ao_emails_response->getError() !== null) {
+        fail('getAutoOrderEmails', $ao_emails_response->getError());
+    }
+    $auto_order_emails = $ao_emails_response->getEmails() ?? [];
+}
+
+// --------------------------------------------------------------------
+// Render the report
+// --------------------------------------------------------------------
+$is_cli = (php_sapi_name() === 'cli');
+if (!$is_cli) echo '<html lang="en"><body><pre>';
+
+renderHeader($order_id);
+renderOrderOverview($order);
+renderSubscription($auto_order, $rebill_orders, $order_id, $auto_order_emails);
+renderEmails($emails);
+renderPageViewHistory($page_views, $session_referrer);
+renderFooter();
+
+if (!$is_cli) echo '</pre></body></html>';
+
+
+// =====================================================================
+// Render helpers
+// =====================================================================
+
+function renderHeader(string $order_id): void {
+    hr('=');
+    echo "  CHARGEBACK EVIDENCE REPORT\n";
+    echo "  UltraCart REST API v2\n";
+    hr('=');
+    echo "\n";
+    kv('Order ID',  $order_id);
+    kv('Generated', gmdate('Y-m-d\TH:i:s\Z'));
+    echo "\n";
+}
+
+function renderOrderOverview($order): void {
+    section('1. ORDER OVERVIEW');
+
+    kv('Placed',       $order->getCreationDate());
+    kv('Stage',        $order->getCurrentStage());
+    kv('Currency',     $order->getCurrencyCode());
+
+    $summary = $order->getSummary();
+    if ($summary !== null) {
+        kv('Order Total', money($summary->getTotal(), $order->getCurrencyCode()));
+    }
+
+    // Customer
+    subsection('Customer');
+    $billing = $order->getBilling();
+    if ($billing !== null) {
+        kv('Name',  trim(($billing->getFirstName() ?? '') . ' ' . ($billing->getLastName() ?? '')));
+        kv('Email', $billing->getEmail());
+        kv('Phone', $billing->getPhone());
+    }
+    $cp = $order->getCustomerProfile();
+    if ($cp !== null) {
+        kv('Customer Profile', 'yes (oid ' . ($cp->getCustomerProfileOid() ?? '?') . ')');
+    } else {
+        kv('Customer Profile', 'no (guest checkout)');
+    }
+    $marketing = $order->getMarketing();
+    if ($marketing !== null && $marketing->getOriginalSourceCode() !== null) {
+        kv('Original Source', $marketing->getOriginalSourceCode());
+    }
+
+    // Addresses
+    subsection('Billing Address');
+    renderAddress($billing);
+
+    subsection('Shipping Address');
+    renderAddress($order->getShipping());
+
+    // Items
+    subsection('Items');
+    $items = $order->getItems() ?? [];
+    foreach ($items as $item) {
+        $sku   = $item->getMerchantItemId() ?? '';
+        $desc  = $item->getDescription() ?? '';
+        $qty   = $item->getQuantity() ?? 0;
+        $cost  = $item->getCost() ?? 0;
+        $total = $qty * $cost;
+        echo sprintf(
+            "  %-12s %-32s qty %s @ %s = %s\n",
+            shorten($sku, 12),
+            shorten($desc, 32),
+            $qty,
+            money($cost, $order->getCurrencyCode()),
+            money($total, $order->getCurrencyCode())
+        );
+    }
+
+    // Totals
+    if ($summary !== null) {
+        echo "\n";
+        kv('Subtotal', money($summary->getSubtotal(), $order->getCurrencyCode()));
+        if ($summary->getTax() !== null)             kv('Tax',      money($summary->getTax(), $order->getCurrencyCode()));
+        if ($summary->getShippingHandling() !== null) kv('Shipping', money($summary->getShippingHandling(), $order->getCurrencyCode()));
+        kv('Total', money($summary->getTotal(), $order->getCurrencyCode()));
+    }
+
+    // Payment
+    subsection('Payment');
+    $payment = $order->getPayment();
+    if ($payment !== null) {
+        kv('Method', $payment->getPaymentMethod());
+        $cc = $payment->getCreditCard();
+        if ($cc !== null) {
+            $card_summary = trim(
+                ($cc->getCardType() ?? '') . ' ending ' . ($cc->getCardNumberTruncated() ?? '????')
+            );
+            kv('Card', $card_summary);
+        }
+        $transactions = $payment->getTransactions() ?? [];
+        if (!empty($transactions)) {
+            subsection('Transactions');
+            foreach ($transactions as $tx) {
+                echo sprintf(
+                    "  %-21s %-12s %-12s %s\n",
+                    $tx->getDts() ?? '',
+                    $tx->getTransactionType() ?? '',
+                    money($tx->getAmount(), $order->getCurrencyCode()),
+                    $tx->getSuccessful() ? 'approved' : 'failed'
+                );
+            }
+        }
+    }
+
+    // Marketing attribution
+    subsection('Marketing / Attribution');
+    $utms = $order->getUtms() ?? [];
+    if ($marketing !== null) {
+        kv('Affiliate ID', $marketing->getAffiliateId() ?? '(none)');
+    }
+    if (empty($utms)) {
+        echo "  No UTM clicks captured.\n";
+    } else {
+        // Index 0 is the most recent click per the API doc.
+        $most_recent = $utms[0];
+        kv('Most recent UTM source',   $most_recent->getUtmSource());
+        kv('Most recent UTM medium',   $most_recent->getUtmMedium());
+        kv('Most recent UTM campaign', $most_recent->getUtmCampaign());
+        kv('UTM clicks captured', (string) count($utms));
+    }
+    echo "\n";
+}
+
+function renderSubscription($auto_order, array $rebill_orders, string $current_order_id, array $auto_order_emails): void {
+    section('2. SUBSCRIPTION DETAILS');
+
+    if ($auto_order === null) {
+        echo "  This order is NOT part of an auto order subscription.\n";
+        echo "\n";
+        return;
+    }
+
+    echo "  This order IS part of an auto order subscription.\n\n";
+    kv('Auto Order Code',     $auto_order->getAutoOrderCode());
+    kv('Status',              $auto_order->getStatus());
+    kv('Enabled',             $auto_order->getEnabled() ? 'yes' : 'no');
+    kv('Original Order',      $auto_order->getOriginalOrderId());
+    kv('Next Attempt',        $auto_order->getNextAttempt() ?? '(none scheduled)');
+    if ($auto_order->getCanceledDts() !== null) {
+        kv('Canceled',          $auto_order->getCanceledDts());
+        kv('Canceled By',       $auto_order->getCancelledByUser() ?? '');
+        kv('Cancel Reason',     $auto_order->getCancelReason() ?? '');
+    }
+    kv('Total Rebills',       (string) count($rebill_orders));
+
+    // Items in plan
+    $ao_items = $auto_order->getItems() ?? [];
+    if (!empty($ao_items)) {
+        subsection('Items in Subscription');
+        foreach ($ao_items as $aoi) {
+            echo sprintf(
+                "  %-12s %-32s frequency: %s\n",
+                shorten($aoi->getOriginalItemId() ?? '', 12),
+                shorten($aoi->getOriginalItemId() ?? '', 32),
+                $aoi->getFrequency() ?? ''
+            );
+        }
+    }
+
+    // Rebill timeline
+    if (!empty($rebill_orders)) {
+        subsection('Rebill Timeline');
+        // Sort by creation date ascending so the earliest rebill is at the top.
+        usort($rebill_orders, function ($a, $b) {
+            return strcmp($a->getCreationDate() ?? '', $b->getCreationDate() ?? '');
+        });
+        foreach ($rebill_orders as $ro) {
+            $ro_id     = $ro->getOrderId() ?? '';
+            $marker    = strcasecmp($ro_id, $current_order_id) === 0 ? '  *** THIS ORDER' : '';
+            $ro_summary = $ro->getSummary();
+            $ro_total   = $ro_summary !== null
+                ? money($ro_summary->getTotal(), $ro->getCurrencyCode() ?? 'USD')
+                : '';
+            echo sprintf(
+                "  %-22s %-22s %-10s %s%s\n",
+                $ro->getCreationDate() ?? '',
+                $ro_id,
+                $ro_total,
+                $ro->getCurrentStage() ?? '',
+                $marker
+            );
+        }
+    }
+
+    // Auto-order-level emails (subscription confirmations, upcoming-rebill notices)
+    if (!empty($auto_order_emails)) {
+        subsection('Subscription-Level Emails (' . count($auto_order_emails) . ')');
+        $i = 1;
+        foreach ($auto_order_emails as $email) {
+            renderEmailDetail($i, $email);
+            $i++;
+        }
+    } else {
+        subsection('Subscription-Level Emails');
+        echo "  No subscription-level emails on record.\n";
+    }
+    echo "\n";
+}
+
+function renderEmails(array $emails): void {
+    section('3. EMAIL DELIVERY (' . count($emails) . ' messages)');
+
+    if (empty($emails)) {
+        echo "  No email delivery records on file for this order.\n";
+        echo "\n";
+        return;
+    }
+
+    $i = 1;
+    foreach ($emails as $email) {
+        renderEmailDetail($i, $email);
+        $i++;
+    }
+    echo "\n";
+}
+
+function renderEmailDetail(int $i, $email): void {
+    echo sprintf("  [%d] sent %s%s\n", $i, $email->getSendDts() ?? '?', $email->getInternal() ? '   (internal copy)' : '');
+    echo sprintf("      To:               %s\n", $email->getEmail() ?? '');
+    echo sprintf("      Subject:          %s\n", $email->getSubject() ?? '');
+
+    // Build a status line that captures the most informative state.
+    $states = [];
+    if ($email->getDelivered())             $states[] = 'DELIVERED';
+    if ($email->getSkipped())               $states[] = 'SKIPPED';
+    if ($email->getBounceDts() !== null)    $states[] = 'BOUNCED ' . $email->getBounceDts();
+    if ($email->getOpened())                $states[] = 'OPENED ' . ($email->getOpenedDts() ?? '');
+    if ($email->getClicked())               $states[] = 'CLICKED ' . ($email->getClickedDts() ?? '');
+    echo sprintf("      Status:           %s\n", empty($states) ? 'unknown' : implode(', ', $states));
+
+    if ($email->getDeliveryDts() !== null)
+        echo sprintf("      Delivered:        %s\n", $email->getDeliveryDts());
+    if ($email->getReportingMTA() !== null)
+        echo sprintf("      Reporting MTA:    %s\n", $email->getReportingMTA());
+    if ($email->getSmtpResponse() !== null)
+        echo sprintf("      SMTP response:    %s\n", $email->getSmtpResponse());
+    if ($email->getBounceType() !== null)
+        echo sprintf("      Bounce type:      %s / %s\n", $email->getBounceType(), $email->getBounceSubType() ?? '');
+    if ($email->getBounceDiagnosticCode() !== null)
+        echo sprintf("      Diagnostic:       %s\n", $email->getBounceDiagnosticCode());
+    if ($email->getSkipReason() !== null)
+        echo sprintf("      Skip reason:      %s\n", $email->getSkipReason());
+    echo "\n";
+}
+
+function renderPageViewHistory(array $page_views, ?string $session_referrer): void {
+    section('4. PAGE VIEW HISTORY (' . count($page_views) . ' views)');
+
+    kv('Session referrer', $session_referrer ?? '(direct or unknown)');
+
+    if (empty($page_views)) {
+        echo "\n  No page views captured for this order's session.\n";
+        echo "\n";
+        return;
+    }
+
+    subsection('Timeline');
+    foreach ($page_views as $pv) {
+        $top   = $pv->getTimeOnPage();
+        $top_s = $top === null ? '   -' : sprintf('%4ds', $top);
+        echo sprintf(
+            "  %-22s %s   %s\n",
+            $pv->getViewDts() ?? '',
+            $top_s,
+            $pv->getUrl() ?? ''
+        );
+    }
+
+    // Time-to-purchase: from first page view to last
+    if (count($page_views) >= 2) {
+        $first_ts = strtotime($page_views[0]->getViewDts() ?? '');
+        $last_ts  = strtotime($page_views[count($page_views) - 1]->getViewDts() ?? '');
+        if ($first_ts && $last_ts && $last_ts > $first_ts) {
+            $elapsed = $last_ts - $first_ts;
+            $mins    = intdiv($elapsed, 60);
+            $secs    = $elapsed % 60;
+            echo "\n";
+            kv('Session length', sprintf('%dm %ds (first view to last view)', $mins, $secs));
+        }
+    }
+
+    // Unique URLs
+    $unique = [];
+    foreach ($page_views as $pv) {
+        $unique[$pv->getUrl() ?? ''] = true;
+    }
+    kv('Unique URLs visited', (string) count($unique));
+    echo "\n";
+}
+
+function renderAddress($address): void {
+    if ($address === null) {
+        echo "  (none on file)\n";
+        return;
+    }
+
+    $name    = trim(($address->getFirstName() ?? '') . ' ' . ($address->getLastName() ?? ''));
+    $company = $address->getCompany() ?? '';
+    $line1   = $address->getAddress1() ?? '';
+    $line2   = $address->getAddress2() ?? '';
+    $cityRow = trim(
+        ($address->getCity() ?? '') .
+        (($address->getState() ?? null) !== null ? ', ' . $address->getState() : '') .
+        ' ' . ($address->getPostalCode() ?? '')
+    );
+    $country = $address->getCountryCode() ?? '';
+
+    foreach (array_filter([$name, $company, $line1, $line2, $cityRow, $country], 'strlen') as $line) {
+        echo "  $line\n";
+    }
+}
+
+function renderFooter(): void {
+    hr('=');
+    echo "  END OF EVIDENCE REPORT\n";
+    hr('=');
+}
+
+// =====================================================================
+// Tiny formatting primitives
+// =====================================================================
+
+function hr(string $char): void {
+    echo str_repeat($char, 80) . "\n";
+}
+
+function section(string $title): void {
+    echo "\n";
+    hr('=');
+    echo "  $title\n";
+    hr('=');
+    echo "\n";
+}
+
+function subsection(string $title): void {
+    echo "\n  $title\n";
+    echo '  ' . str_repeat('-', strlen($title)) . "\n";
+}
+
+function kv(string $label, ?string $value): void {
+    echo sprintf("  %-22s %s\n", $label . ':', $value ?? '');
+}
+
+function money(?float $amount, ?string $currency): string {
+    if ($amount === null) return '';
+    return sprintf('%s%s %s', $amount < 0 ? '-' : '', '$' . number_format(abs($amount), 2), $currency ?? '');
+}
+
+function shorten(string $s, int $max): string {
+    return mb_strlen($s) <= $max ? $s : mb_substr($s, 0, $max - 1) . '~';
+}
+
+function fail(string $operation, $error): void {
+    echo "ERROR in $operation:\n";
+    echo "  Developer message: " . ($error->getDeveloperMessage() ?? '') . "\n";
+    echo "  User message:      " . ($error->getUserMessage() ?? '') . "\n";
+    exit(1);
+}

--- a/php/order/getChargebackEvidence.php
+++ b/php/order/getChargebackEvidence.php
@@ -209,10 +209,14 @@ function renderOrderOverview($order): void {
     subsection('Shipping Address');
     renderAddress($order->getShipping());
 
-    // Items
+    // Items - skip kit components (they're sub-rows of a parent kit, not
+    // independently-purchased items, and printing them inflates the list).
     subsection('Items');
     $items = $order->getItems() ?? [];
     foreach ($items as $item) {
+        if ($item->getKitComponent()) {
+            continue;
+        }
         $sku   = $item->getMerchantItemId() ?? '';
         $desc  = $item->getDescription() ?? '';
         $qty   = $item->getQuantity() ?? 0;

--- a/php/order/getChargebackEvidence.php
+++ b/php/order/getChargebackEvidence.php
@@ -180,7 +180,7 @@ function renderOrderOverview($order): void {
 
     $summary = $order->getSummary();
     if ($summary !== null) {
-        kv('Order Total', money($summary->getTotal(), $order->getCurrencyCode()));
+        kv('Order Total', money(moneyValue($summary->getTotal()), $order->getCurrencyCode()));
     }
 
     // Customer
@@ -189,7 +189,8 @@ function renderOrderOverview($order): void {
     if ($billing !== null) {
         kv('Name',  trim(($billing->getFirstName() ?? '') . ' ' . ($billing->getLastName() ?? '')));
         kv('Email', $billing->getEmail());
-        kv('Phone', $billing->getPhone());
+        // First populated phone wins - billing has separate day/evening/cell fields
+        kv('Phone', $billing->getDayPhone() ?? $billing->getEveningPhone() ?? $billing->getCellPhone());
     }
     $cp = $order->getCustomerProfile();
     if ($cp !== null) {
@@ -198,8 +199,11 @@ function renderOrderOverview($order): void {
         kv('Customer Profile', 'no (guest checkout)');
     }
     $marketing = $order->getMarketing();
-    if ($marketing !== null && $marketing->getOriginalSourceCode() !== null) {
-        kv('Original Source', $marketing->getOriginalSourceCode());
+    if ($marketing !== null && $marketing->getAdvertisingSource() !== null) {
+        kv('Advertising Source', $marketing->getAdvertisingSource());
+    }
+    if ($marketing !== null && $marketing->getReferralCode() !== null) {
+        kv('Referral Code', $marketing->getReferralCode());
     }
 
     // Addresses
@@ -220,7 +224,7 @@ function renderOrderOverview($order): void {
         $sku   = $item->getMerchantItemId() ?? '';
         $desc  = $item->getDescription() ?? '';
         $qty   = $item->getQuantity() ?? 0;
-        $cost  = $item->getCost() ?? 0;
+        $cost  = moneyValue($item->getCost()) ?? 0; // OrderItem.cost is a Currency object
         $total = $qty * $cost;
         echo sprintf(
             "  %-12s %-32s qty %s @ %s = %s\n",
@@ -232,13 +236,15 @@ function renderOrderOverview($order): void {
         );
     }
 
-    // Totals
+    // Totals - OrderSummary money fields are Currency objects
     if ($summary !== null) {
         echo "\n";
-        kv('Subtotal', money($summary->getSubtotal(), $order->getCurrencyCode()));
-        if ($summary->getTax() !== null)             kv('Tax',      money($summary->getTax(), $order->getCurrencyCode()));
-        if ($summary->getShippingHandling() !== null) kv('Shipping', money($summary->getShippingHandling(), $order->getCurrencyCode()));
-        kv('Total', money($summary->getTotal(), $order->getCurrencyCode()));
+        kv('Subtotal', money(moneyValue($summary->getSubtotal()), $order->getCurrencyCode()));
+        if ($summary->getTax() !== null)
+            kv('Tax', money(moneyValue($summary->getTax()), $order->getCurrencyCode()));
+        if ($summary->getShippingHandlingTotal() !== null)
+            kv('Shipping', money(moneyValue($summary->getShippingHandlingTotal()), $order->getCurrencyCode()));
+        kv('Total', money(moneyValue($summary->getTotal()), $order->getCurrencyCode()));
     }
 
     // Payment
@@ -258,10 +264,9 @@ function renderOrderOverview($order): void {
             subsection('Transactions');
             foreach ($transactions as $tx) {
                 echo sprintf(
-                    "  %-21s %-12s %-12s %s\n",
-                    $tx->getDts() ?? '',
-                    $tx->getTransactionType() ?? '',
-                    money($tx->getAmount(), $order->getCurrencyCode()),
+                    "  %-21s %-30s %s\n",
+                    $tx->getTransactionTimestamp() ?? '',
+                    shorten($tx->getTransactionGateway() ?? '', 30),
                     $tx->getSuccessful() ? 'approved' : 'failed'
                 );
             }
@@ -271,9 +276,9 @@ function renderOrderOverview($order): void {
     // Marketing attribution
     subsection('Marketing / Attribution');
     $utms = $order->getUtms() ?? [];
-    if ($marketing !== null) {
-        kv('Affiliate ID', $marketing->getAffiliateId() ?? '(none)');
-    }
+    // Affiliate attribution lives on OrderAffiliate (expansion=affiliate); not pulled
+    // here to keep the chargeback request light. Add 'affiliate' to the order
+    // expansion list above if you need it.
     if (empty($utms)) {
         echo "  No UTM clicks captured.\n";
     } else {
@@ -335,7 +340,7 @@ function renderSubscription($auto_order, array $rebill_orders, string $current_o
             $marker    = strcasecmp($ro_id, $current_order_id) === 0 ? '  *** THIS ORDER' : '';
             $ro_summary = $ro->getSummary();
             $ro_total   = $ro_summary !== null
-                ? money($ro_summary->getTotal(), $ro->getCurrencyCode() ?? 'USD')
+                ? money(moneyValue($ro_summary->getTotal()), $ro->getCurrencyCode() ?? 'USD')
                 : '';
             echo sprintf(
                 "  %-22s %-22s %-10s %s%s\n",
@@ -473,7 +478,7 @@ function renderAddress($address): void {
     $line2   = $address->getAddress2() ?? '';
     $cityRow = trim(
         ($address->getCity() ?? '') .
-        (($address->getState() ?? null) !== null ? ', ' . $address->getState() : '') .
+        (($address->getStateRegion() ?? null) !== null ? ', ' . $address->getStateRegion() : '') .
         ' ' . ($address->getPostalCode() ?? '')
     );
     $country = $address->getCountryCode() ?? '';
@@ -512,6 +517,13 @@ function subsection(string $title): void {
 
 function kv(string $label, ?string $value): void {
     echo sprintf("  %-22s %s\n", $label . ':', $value ?? '');
+}
+
+// SDK money fields are Currency objects, not raw numbers. Pull the localized
+// value off; null-safe for missing/optional fields.
+function moneyValue($currency): ?float {
+    if ($currency === null) return null;
+    return $currency->getLocalized();
 }
 
 function money(?float $amount, ?string $currency): string {

--- a/python/order/get_chargeback_evidence.py
+++ b/python/order/get_chargeback_evidence.py
@@ -1,0 +1,387 @@
+"""
+get_chargeback_evidence.py
+
+Pulls everything from UltraCart that is useful when fighting a chargeback
+dispute and prints a formatted evidence report. Designed as a starting point
+for building the actual evidence packet you submit to the card processor.
+
+What this sample demonstrates:
+  1. Order detail with the SPECIFIC expansions a chargeback case relies on.
+     Notice we list every expansion explicitly - no shortcuts. Listing them
+     individually keeps your payload small and forces you to think about
+     what evidence each one represents.
+  2. Email delivery records via the dedicated /emails endpoint (not via
+     expansion). Use the dedicated endpoint for chargeback work - it is the
+     canonical full-fidelity source for SES delivery events on every order.
+  3. Page view history (the customer was on your site, navigated through
+     pages, spent time before placing the order).
+  4. Auto-order detection: a large fraction of chargebacks are subscription
+     disputes ("I never authorized this rebill"). When the order is part of
+     an auto order, this sample pulls the parent subscription, every rebill
+     that has occurred on it, and the auto-order-level email log. For rebills
+     specifically, the page-view lookup pivots to the ORIGINAL order, since
+     the rebill itself has no checkout session.
+
+Usage:
+    PYTHONPATH=. python order/get_chargeback_evidence.py DEMO-0009104976
+
+Requires the May 2026 SDK build that includes get_order_emails,
+get_order_page_view_history, and get_auto_order_emails.
+"""
+
+import sys
+from datetime import datetime
+
+from ultracart.apis import OrderApi, AutoOrderApi
+from samples import api_client
+
+
+# --------------------------------------------------------------------
+# Configuration
+# --------------------------------------------------------------------
+order_id = sys.argv[1] if len(sys.argv) > 1 else "DEMO-0009104976"
+
+client = api_client()
+order_api = OrderApi(client)
+auto_order_api = AutoOrderApi(client)
+
+# Listing expansions individually (rather than relying on a catch-all) keeps
+# payload size predictable and makes it obvious what evidence each piece is
+# providing. Add or remove based on what your dispute reason code requires.
+order_expansion = ",".join([
+    "billing",                  # address customer entered for billing
+    "shipping",                 # address goods shipped to
+    "payment",                  # payment method, card last four, gateway info
+    "payment.transaction",      # auth/capture/refund timeline
+    "summary",                  # totals, tax, shipping, weights
+    "items",                    # line items the customer ordered
+    "coupon",                   # discounts the customer chose to apply
+    "customer_profile",         # returning-customer signal, account history
+    "auto_order",               # detect subscription chargebacks
+    "utms",                     # entry-path UTM clicks (attribution chain)
+    "marketing",                # affiliate / source-code attribution
+    "gift",                     # gift-giving intent if applicable
+    "point_of_sale",            # POS terminal / location for retail orders
+    "channel_partner",          # channel partner data (Amazon, eBay, etc.)
+])
+
+auto_order_expansion = ",".join([
+    "items",                    # subscription line items + frequency
+    "rebill_orders",            # every rebill that has occurred
+    "logs",                     # status changes, payment attempts, cancellations
+    "management",               # self-service management state
+])
+
+
+# --------------------------------------------------------------------
+# Pull the data
+# --------------------------------------------------------------------
+def fail(operation, error):
+    print(f"ERROR in {operation}:")
+    print(f"  Developer message: {error.developer_message}")
+    print(f"  User message:      {error.user_message}")
+    sys.exit(1)
+
+
+order_response = order_api.get_order(order_id, expand=order_expansion)
+if getattr(order_response, "error", None):
+    fail("get_order", order_response.error)
+order = order_response.order
+
+# Use the dedicated /emails endpoint rather than _expand=emails. The dedicated
+# endpoint is the canonical full-fidelity source for SES delivery events.
+emails_response = order_api.get_order_emails(order_id)
+if getattr(emails_response, "error", None):
+    fail("get_order_emails", emails_response.error)
+emails = emails_response.emails or []
+
+# Auto-order chain (if applicable). Resolve this BEFORE pulling page views
+# because a rebill's own page view history is empty - the customer never went
+# through checkout for the rebill, so the meaningful history lives on the
+# original order that started the subscription.
+auto_order = None
+auto_order_emails = []
+rebill_orders = []
+auto_order_pointer = order.auto_order  # populated by ?_expand=auto_order
+if auto_order_pointer is not None and auto_order_pointer.auto_order_oid is not None:
+    auto_order_oid = auto_order_pointer.auto_order_oid
+
+    ao_response = auto_order_api.get_auto_order(auto_order_oid, expand=auto_order_expansion)
+    if getattr(ao_response, "error", None):
+        fail("get_auto_order", ao_response.error)
+    auto_order = ao_response.auto_order
+    rebill_orders = auto_order.rebill_orders or []
+
+    ao_emails_response = auto_order_api.get_auto_order_emails(auto_order_oid)
+    if getattr(ao_emails_response, "error", None):
+        fail("get_auto_order_emails", ao_emails_response.error)
+    auto_order_emails = ao_emails_response.emails or []
+
+# For a rebill chargeback, the page view history that matters is the one from
+# the ORIGINAL order's checkout session.
+page_view_order_id = order_id
+page_view_is_redirected = False
+if auto_order is not None:
+    original_order_id = auto_order.original_order_id
+    if original_order_id and original_order_id.lower() != order_id.lower():
+        page_view_order_id = original_order_id
+        page_view_is_redirected = True
+
+page_view_response = order_api.get_order_page_view_history(page_view_order_id)
+if getattr(page_view_response, "error", None):
+    fail("get_order_page_view_history", page_view_response.error)
+page_views = page_view_response.page_views or []
+session_referrer = page_view_response.referrer
+
+
+# --------------------------------------------------------------------
+# Tiny formatting primitives
+# --------------------------------------------------------------------
+def hr(char="="):
+    print(char * 80)
+
+
+def section(title):
+    print()
+    hr("=")
+    print(f"  {title}")
+    hr("=")
+    print()
+
+
+def subsection(title):
+    print()
+    print(f"  {title}")
+    print("  " + "-" * len(title))
+
+
+def kv(label, value, width=22):
+    print(f"  {(label + ':').ljust(width)} {value if value is not None else ''}")
+
+
+def money(amount, currency):
+    if amount is None:
+        return ""
+    sign = "-" if amount < 0 else ""
+    return f"{sign}${abs(amount):,.2f} {currency or ''}"
+
+
+def shorten(s, n):
+    s = s or ""
+    return s if len(s) <= n else s[: n - 1] + "~"
+
+
+# --------------------------------------------------------------------
+# Render the report
+# --------------------------------------------------------------------
+def render_address(address):
+    if address is None:
+        print("  (none on file)")
+        return
+    name = " ".join(filter(None, [address.first_name, address.last_name])).strip()
+    company = address.company or ""
+    line1 = address.address1 or ""
+    line2 = address.address2 or ""
+    city_row = (
+        (address.city or "")
+        + (f", {address.state}" if address.state else "")
+        + " " + (address.postal_code or "")
+    ).strip()
+    country = address.country_code or ""
+    for line in filter(None, [name, company, line1, line2, city_row, country]):
+        print(f"  {line}")
+
+
+def render_email_detail(i, email):
+    internal = "   (internal copy)" if email.internal else ""
+    print(f"  [{i}] sent {email.send_dts or '?'}{internal}")
+    print(f"      To:               {email.email or ''}")
+    print(f"      Subject:          {email.subject or ''}")
+
+    states = []
+    if email.delivered:                 states.append("DELIVERED")
+    if email.skipped:                   states.append("SKIPPED")
+    if email.bounce_dts is not None:    states.append(f"BOUNCED {email.bounce_dts}")
+    if email.opened:                    states.append(f"OPENED {email.opened_dts or ''}")
+    if email.clicked:                   states.append(f"CLICKED {email.clicked_dts or ''}")
+    print(f"      Status:           {', '.join(states) if states else 'unknown'}")
+
+    if email.delivery_dts:           print(f"      Delivered:        {email.delivery_dts}")
+    if email.reporting_mta:          print(f"      Reporting MTA:    {email.reporting_mta}")
+    if email.smtp_response:          print(f"      SMTP response:    {email.smtp_response}")
+    if email.bounce_type:            print(f"      Bounce type:      {email.bounce_type} / {email.bounce_sub_type or ''}")
+    if email.bounce_diagnostic_code: print(f"      Diagnostic:       {email.bounce_diagnostic_code}")
+    if email.skip_reason:            print(f"      Skip reason:      {email.skip_reason}")
+    print()
+
+
+# Header
+hr("=")
+print("  CHARGEBACK EVIDENCE REPORT")
+print("  UltraCart REST API v2")
+hr("=")
+print()
+kv("Order ID", order_id)
+kv("Generated", datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"))
+
+# Section 1: Order overview
+section("1. ORDER OVERVIEW")
+kv("Placed", order.creation_dts)
+kv("Stage", order.current_stage)
+kv("Currency", order.currency_code)
+if order.summary is not None:
+    kv("Order Total", money(order.summary.total, order.currency_code))
+
+subsection("Customer")
+billing = order.billing
+if billing is not None:
+    name = " ".join(filter(None, [billing.first_name, billing.last_name])).strip()
+    kv("Name", name)
+    kv("Email", billing.email)
+    kv("Phone", billing.phone)
+cp = order.customer_profile
+if cp is not None:
+    kv("Customer Profile", f"yes (oid {cp.customer_profile_oid or '?'})")
+else:
+    kv("Customer Profile", "no (guest checkout)")
+marketing = order.marketing
+if marketing is not None and marketing.original_source_code:
+    kv("Original Source", marketing.original_source_code)
+
+subsection("Billing Address")
+render_address(billing)
+
+subsection("Shipping Address")
+render_address(order.shipping)
+
+subsection("Items")
+for item in order.items or []:
+    if item.kit_component:  # skip kit components - they are sub-rows of a parent kit
+        continue
+    qty = item.quantity or 0
+    cost = item.cost or 0
+    print(f"  {shorten(item.merchant_item_id or '', 12).ljust(12)} {shorten(item.description or '', 32).ljust(32)} qty {qty} @ {money(cost, order.currency_code)} = {money(qty * cost, order.currency_code)}")
+
+if order.summary is not None:
+    print()
+    kv("Subtotal", money(order.summary.subtotal, order.currency_code))
+    if order.summary.tax is not None:                kv("Tax", money(order.summary.tax, order.currency_code))
+    if order.summary.shipping_handling is not None:  kv("Shipping", money(order.summary.shipping_handling, order.currency_code))
+    kv("Total", money(order.summary.total, order.currency_code))
+
+subsection("Payment")
+payment = order.payment
+if payment is not None:
+    kv("Method", payment.payment_method)
+    cc = payment.credit_card
+    if cc is not None:
+        card_summary = f"{cc.card_type or ''} ending {cc.card_number_truncated or '????'}".strip()
+        kv("Card", card_summary)
+    transactions = payment.transactions or []
+    if transactions:
+        subsection("Transactions")
+        for tx in transactions:
+            status = "approved" if tx.successful else "failed"
+            print(f"  {(tx.dts or '').ljust(21)} {(tx.transaction_type or '').ljust(12)} {money(tx.amount, order.currency_code).ljust(12)} {status}")
+
+subsection("Marketing / Attribution")
+utms = order.utms or []
+if marketing is not None:
+    kv("Affiliate ID", marketing.affiliate_id or "(none)")
+if not utms:
+    print("  No UTM clicks captured.")
+else:
+    most_recent = utms[0]  # index 0 is most recent click
+    kv("Most recent UTM source",   most_recent.utm_source)
+    kv("Most recent UTM medium",   most_recent.utm_medium)
+    kv("Most recent UTM campaign", most_recent.utm_campaign)
+    kv("UTM clicks captured", str(len(utms)))
+
+# Section 2: Subscription
+section("2. SUBSCRIPTION DETAILS")
+if auto_order is None:
+    print("  This order is NOT part of an auto order subscription.")
+else:
+    print("  This order IS part of an auto order subscription.")
+    print()
+    kv("Auto Order Code", auto_order.auto_order_code)
+    kv("Status", auto_order.status)
+    kv("Enabled", "yes" if auto_order.enabled else "no")
+    kv("Original Order", auto_order.original_order_id)
+    kv("Next Attempt", auto_order.next_attempt or "(none scheduled)")
+    if auto_order.canceled_dts is not None:
+        kv("Canceled", auto_order.canceled_dts)
+        kv("Canceled By", auto_order.canceled_by_user or "")
+        kv("Cancel Reason", auto_order.cancel_reason or "")
+    kv("Total Rebills", str(len(rebill_orders)))
+
+    ao_items = auto_order.items or []
+    if ao_items:
+        subsection("Items in Subscription")
+        for aoi in ao_items:
+            print(f"  {shorten(aoi.original_item_id or '', 12).ljust(12)} {shorten(aoi.original_item_id or '', 32).ljust(32)} frequency: {aoi.frequency or ''}")
+
+    if rebill_orders:
+        subsection("Rebill Timeline")
+        rebill_orders.sort(key=lambda r: r.creation_dts or "")
+        for ro in rebill_orders:
+            ro_id = ro.order_id or ""
+            marker = "  *** THIS ORDER" if ro_id.lower() == order_id.lower() else ""
+            ro_total = money(ro.summary.total, ro.currency_code or "USD") if ro.summary else ""
+            print(f"  {(ro.creation_dts or '').ljust(22)} {ro_id.ljust(22)} {ro_total.ljust(10)} {ro.current_stage or ''}{marker}")
+
+    if auto_order_emails:
+        subsection(f"Subscription-Level Emails ({len(auto_order_emails)})")
+        for i, email in enumerate(auto_order_emails, start=1):
+            render_email_detail(i, email)
+    else:
+        subsection("Subscription-Level Emails")
+        print("  No subscription-level emails on record.")
+
+# Section 3: Emails
+section(f"3. EMAIL DELIVERY ({len(emails)} messages)")
+if not emails:
+    print("  No email delivery records on file for this order.")
+else:
+    for i, email in enumerate(emails, start=1):
+        render_email_detail(i, email)
+
+# Section 4: Page view history
+section(f"4. PAGE VIEW HISTORY ({len(page_views)} views)")
+if page_view_is_redirected:
+    print("  Note: this is a subscription rebill. The disputed order itself has no")
+    print("  checkout session of its own. The page views below are from the ORIGINAL")
+    print("  order that started the subscription, where the customer's intent was")
+    print("  captured during signup.")
+    print()
+    kv("Source order", page_view_order_id)
+kv("Session referrer", session_referrer or "(direct or unknown)")
+
+if not page_views:
+    print()
+    print(f"  No page views captured{' for the original order.' if page_view_is_redirected else ' for this order session.'}")
+else:
+    subsection("Timeline")
+    for pv in page_views:
+        top_s = "   -" if pv.time_on_page is None else f"{pv.time_on_page:4d}s"
+        print(f"  {(pv.view_dts or '').ljust(22)} {top_s}   {pv.url or ''}")
+
+    if len(page_views) >= 2:
+        try:
+            first = datetime.fromisoformat((page_views[0].view_dts or "").replace("Z", "+00:00"))
+            last = datetime.fromisoformat((page_views[-1].view_dts or "").replace("Z", "+00:00"))
+            elapsed = int((last - first).total_seconds())
+            if elapsed > 0:
+                mins, secs = divmod(elapsed, 60)
+                print()
+                kv("Session length", f"{mins}m {secs}s (first view to last view)")
+        except (ValueError, TypeError):
+            pass
+    unique_urls = {pv.url for pv in page_views if pv.url}
+    kv("Unique URLs visited", str(len(unique_urls)))
+
+# Footer
+print()
+hr("=")
+print("  END OF EVIDENCE REPORT")
+hr("=")

--- a/python/order/get_chargeback_evidence.py
+++ b/python/order/get_chargeback_evidence.py
@@ -159,6 +159,14 @@ def kv(label, value, width=22):
     print(f"  {(label + ':').ljust(width)} {value if value is not None else ''}")
 
 
+# SDK money fields are Currency objects, not raw numbers. Pull the localized
+# value off; None-safe for missing/optional fields.
+def money_value(currency):
+    if currency is None:
+        return None
+    return getattr(currency, "localized", None)
+
+
 def money(amount, currency):
     if amount is None:
         return ""
@@ -184,7 +192,7 @@ def render_address(address):
     line2 = address.address2 or ""
     city_row = (
         (address.city or "")
-        + (f", {address.state}" if address.state else "")
+        + (f", {address.state_region}" if address.state_region else "")
         + " " + (address.postal_code or "")
     ).strip()
     country = address.country_code or ""
@@ -230,7 +238,7 @@ kv("Placed", order.creation_dts)
 kv("Stage", order.current_stage)
 kv("Currency", order.currency_code)
 if order.summary is not None:
-    kv("Order Total", money(order.summary.total, order.currency_code))
+    kv("Order Total", money(money_value(order.summary.total), order.currency_code))
 
 subsection("Customer")
 billing = order.billing
@@ -238,15 +246,18 @@ if billing is not None:
     name = " ".join(filter(None, [billing.first_name, billing.last_name])).strip()
     kv("Name", name)
     kv("Email", billing.email)
-    kv("Phone", billing.phone)
+    # First populated phone wins
+    kv("Phone", billing.day_phone or billing.evening_phone or billing.cell_phone)
 cp = order.customer_profile
 if cp is not None:
     kv("Customer Profile", f"yes (oid {cp.customer_profile_oid or '?'})")
 else:
     kv("Customer Profile", "no (guest checkout)")
 marketing = order.marketing
-if marketing is not None and marketing.original_source_code:
-    kv("Original Source", marketing.original_source_code)
+if marketing is not None and getattr(marketing, "advertising_source", None):
+    kv("Advertising Source", marketing.advertising_source)
+if marketing is not None and getattr(marketing, "referral_code", None):
+    kv("Referral Code", marketing.referral_code)
 
 subsection("Billing Address")
 render_address(billing)
@@ -259,15 +270,17 @@ for item in order.items or []:
     if item.kit_component:  # skip kit components - they are sub-rows of a parent kit
         continue
     qty = item.quantity or 0
-    cost = item.cost or 0
+    cost = money_value(item.cost) or 0  # OrderItem.cost is a Currency object
     print(f"  {shorten(item.merchant_item_id or '', 12).ljust(12)} {shorten(item.description or '', 32).ljust(32)} qty {qty} @ {money(cost, order.currency_code)} = {money(qty * cost, order.currency_code)}")
 
 if order.summary is not None:
     print()
-    kv("Subtotal", money(order.summary.subtotal, order.currency_code))
-    if order.summary.tax is not None:                kv("Tax", money(order.summary.tax, order.currency_code))
-    if order.summary.shipping_handling is not None:  kv("Shipping", money(order.summary.shipping_handling, order.currency_code))
-    kv("Total", money(order.summary.total, order.currency_code))
+    kv("Subtotal", money(money_value(order.summary.subtotal), order.currency_code))
+    if order.summary.tax is not None:
+        kv("Tax", money(money_value(order.summary.tax), order.currency_code))
+    if getattr(order.summary, "shipping_handling_total", None) is not None:
+        kv("Shipping", money(money_value(order.summary.shipping_handling_total), order.currency_code))
+    kv("Total", money(money_value(order.summary.total), order.currency_code))
 
 subsection("Payment")
 payment = order.payment
@@ -282,12 +295,12 @@ if payment is not None:
         subsection("Transactions")
         for tx in transactions:
             status = "approved" if tx.successful else "failed"
-            print(f"  {(tx.dts or '').ljust(21)} {(tx.transaction_type or '').ljust(12)} {money(tx.amount, order.currency_code).ljust(12)} {status}")
+            print(f"  {(tx.transaction_timestamp or '').ljust(21)} {shorten(tx.transaction_gateway or '', 30).ljust(30)} {status}")
 
 subsection("Marketing / Attribution")
 utms = order.utms or []
-if marketing is not None:
-    kv("Affiliate ID", marketing.affiliate_id or "(none)")
+# Affiliate attribution lives on OrderAffiliate (expansion=affiliate); not pulled
+# here to keep the chargeback request light.
 if not utms:
     print("  No UTM clicks captured.")
 else:
@@ -327,7 +340,7 @@ else:
         for ro in rebill_orders:
             ro_id = ro.order_id or ""
             marker = "  *** THIS ORDER" if ro_id.lower() == order_id.lower() else ""
-            ro_total = money(ro.summary.total, ro.currency_code or "USD") if ro.summary else ""
+            ro_total = money(money_value(ro.summary.total), ro.currency_code or "USD") if ro.summary else ""
             print(f"  {(ro.creation_dts or '').ljust(22)} {ro_id.ljust(22)} {ro_total.ljust(10)} {ro.current_stage or ''}{marker}")
 
     if auto_order_emails:

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'rubocop', group: 'development'
-gem 'ultracart_api', '4.1.15'
+gem 'ultracart_api', '4.1.88'

--- a/ruby/order/get_chargeback_evidence.rb
+++ b/ruby/order/get_chargeback_evidence.rb
@@ -1,0 +1,405 @@
+# get_chargeback_evidence.rb
+#
+# Pulls everything from UltraCart that is useful when fighting a chargeback
+# dispute and prints a formatted evidence report. Designed as a starting point
+# for building the actual evidence packet you submit to the card processor.
+#
+# What this sample demonstrates:
+#   1. Order detail with the SPECIFIC expansions a chargeback case relies on.
+#      Notice we list every expansion explicitly - no shortcuts. Listing them
+#      individually keeps your payload small and forces you to think about
+#      what evidence each one represents.
+#   2. Email delivery records via the dedicated /emails endpoint (not via
+#      expansion). Use the dedicated endpoint for chargeback work - it is the
+#      canonical full-fidelity source for SES delivery events on every order.
+#   3. Page view history (the customer was on your site, navigated through
+#      pages, spent time before placing the order).
+#   4. Auto-order detection: a large fraction of chargebacks are subscription
+#      disputes ("I never authorized this rebill"). When the order is part of
+#      an auto order, this sample pulls the parent subscription, every rebill
+#      that has occurred on it, and the auto-order-level email log. For rebills
+#      specifically, the page-view lookup pivots to the ORIGINAL order, since
+#      the rebill itself has no checkout session.
+#
+# Usage:
+#   ruby order/get_chargeback_evidence.rb DEMO-0009104976
+#
+# Requires the May 2026 SDK build that includes get_order_emails,
+# get_order_page_view_history, and get_auto_order_emails.
+
+require 'ultracart_api'
+require 'date'
+require_relative '../constants'
+
+order_id = ARGV[0] || 'DEMO-0009104976'
+
+order_api      = UltracartClient::OrderApi.new_using_api_key(Constants::API_KEY)
+auto_order_api = UltracartClient::AutoOrderApi.new_using_api_key(Constants::API_KEY)
+
+# Listing expansions individually (rather than relying on a catch-all) keeps
+# payload size predictable and makes it obvious what evidence each piece is
+# providing. Add or remove based on what your dispute reason code requires.
+order_expansion = %w[
+  billing
+  shipping
+  payment
+  payment.transaction
+  summary
+  items
+  coupon
+  customer_profile
+  auto_order
+  utms
+  marketing
+  gift
+  point_of_sale
+  channel_partner
+].join(',')
+
+auto_order_expansion = %w[items rebill_orders logs management].join(',')
+
+# --------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------
+def fail_op(operation, error)
+  puts "ERROR in #{operation}:"
+  puts "  Developer message: #{error.developer_message}"
+  puts "  User message:      #{error.user_message}"
+  exit 1
+end
+
+def hr(char = '=')
+  puts char * 80
+end
+
+def section(title)
+  puts
+  hr('=')
+  puts "  #{title}"
+  hr('=')
+  puts
+end
+
+def subsection(title)
+  puts
+  puts "  #{title}"
+  puts "  #{'-' * title.length}"
+end
+
+def kv(label, value, width = 22)
+  puts "  #{(label + ':').ljust(width)} #{value || ''}"
+end
+
+def money(amount, currency)
+  return '' if amount.nil?
+
+  sign = amount.negative? ? '-' : ''
+  format("#{sign}$%s %s", amount.abs.to_f.round(2), currency || '').strip
+end
+
+def shorten(str, max)
+  s = str || ''
+  s.length <= max ? s : s[0, max - 1] + '~'
+end
+
+def render_address(addr)
+  if addr.nil?
+    puts '  (none on file)'
+    return
+  end
+
+  name = [addr.first_name, addr.last_name].compact.join(' ').strip
+  city_row = [addr.city, addr.state].compact.reject(&:empty?).join(', ').strip
+  city_row = "#{city_row} #{addr.postal_code}".strip if addr.postal_code
+
+  [name, addr.company, addr.address1, addr.address2, city_row, addr.country_code]
+    .reject { |line| line.nil? || line.strip.empty? }
+    .each { |line| puts "  #{line}" }
+end
+
+def render_email_detail(idx, email)
+  internal = email.internal ? '   (internal copy)' : ''
+  puts "  [#{idx}] sent #{email.send_dts || '?'}#{internal}"
+  puts "      To:               #{email.email || ''}"
+  puts "      Subject:          #{email.subject || ''}"
+
+  states = []
+  states << 'DELIVERED'                                        if email.delivered
+  states << 'SKIPPED'                                          if email.skipped
+  states << "BOUNCED #{email.bounce_dts}"                      unless email.bounce_dts.nil?
+  states << "OPENED #{email.opened_dts || ''}"                 if email.opened
+  states << "CLICKED #{email.clicked_dts || ''}"               if email.clicked
+  puts "      Status:           #{states.empty? ? 'unknown' : states.join(', ')}"
+
+  puts "      Delivered:        #{email.delivery_dts}"           unless email.delivery_dts.nil?
+  puts "      Reporting MTA:    #{email.reporting_mta}"          unless email.reporting_mta.nil?
+  puts "      SMTP response:    #{email.smtp_response}"          unless email.smtp_response.nil?
+  puts "      Bounce type:      #{email.bounce_type} / #{email.bounce_sub_type || ''}" unless email.bounce_type.nil?
+  puts "      Diagnostic:       #{email.bounce_diagnostic_code}" unless email.bounce_diagnostic_code.nil?
+  puts "      Skip reason:      #{email.skip_reason}"            unless email.skip_reason.nil?
+  puts
+end
+
+# --------------------------------------------------------------------
+# Pull the data
+# --------------------------------------------------------------------
+order_response = order_api.get_order(order_id, '_expand' => order_expansion)
+fail_op('get_order', order_response.error) if order_response.error
+order = order_response.order
+
+# Use the dedicated /emails endpoint rather than _expand=emails. The dedicated
+# endpoint is the canonical full-fidelity source for SES delivery events.
+emails_response = order_api.get_order_emails(order_id)
+fail_op('get_order_emails', emails_response.error) if emails_response.error
+emails = emails_response.emails || []
+
+# Auto-order chain (if applicable). Resolve this BEFORE pulling page views
+# because a rebill's own page view history is empty - the customer never went
+# through checkout for the rebill, so the meaningful history lives on the
+# original order that started the subscription.
+auto_order        = nil
+auto_order_emails = []
+rebill_orders     = []
+auto_order_pointer = order.auto_order
+if !auto_order_pointer.nil? && !auto_order_pointer.auto_order_oid.nil?
+  auto_order_oid = auto_order_pointer.auto_order_oid
+
+  ao_response = auto_order_api.get_auto_order(auto_order_oid, '_expand' => auto_order_expansion)
+  fail_op('get_auto_order', ao_response.error) if ao_response.error
+  auto_order    = ao_response.auto_order
+  rebill_orders = auto_order.rebill_orders || []
+
+  ao_emails_response = auto_order_api.get_auto_order_emails(auto_order_oid)
+  fail_op('get_auto_order_emails', ao_emails_response.error) if ao_emails_response.error
+  auto_order_emails = ao_emails_response.emails || []
+end
+
+# For a rebill chargeback, the page view history that matters is the one from
+# the ORIGINAL order's checkout session.
+page_view_order_id      = order_id
+page_view_is_redirected = false
+if !auto_order.nil? &&
+   !auto_order.original_order_id.nil? &&
+   auto_order.original_order_id.casecmp(order_id) != 0
+  page_view_order_id      = auto_order.original_order_id
+  page_view_is_redirected = true
+end
+
+page_view_response = order_api.get_order_page_view_history(page_view_order_id)
+fail_op('get_order_page_view_history', page_view_response.error) if page_view_response.error
+page_views       = page_view_response.page_views || []
+session_referrer = page_view_response.referrer
+
+# --------------------------------------------------------------------
+# Render the report
+# --------------------------------------------------------------------
+hr('=')
+puts '  CHARGEBACK EVIDENCE REPORT'
+puts '  UltraCart REST API v2'
+hr('=')
+puts
+kv('Order ID', order_id)
+kv('Generated', Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ'))
+
+# Section 1: Order overview
+section('1. ORDER OVERVIEW')
+kv('Placed',   order.creation_dts)
+kv('Stage',    order.current_stage)
+kv('Currency', order.currency_code)
+kv('Order Total', money(order.summary.total, order.currency_code)) if order.summary
+
+subsection('Customer')
+billing = order.billing
+if billing
+  kv('Name', [billing.first_name, billing.last_name].compact.join(' ').strip)
+  kv('Email', billing.email)
+  kv('Phone', billing.phone)
+end
+cp = order.customer_profile
+if cp
+  kv('Customer Profile', "yes (oid #{cp.customer_profile_oid || '?'})")
+else
+  kv('Customer Profile', 'no (guest checkout)')
+end
+marketing = order.marketing
+kv('Original Source', marketing.original_source_code) if marketing && marketing.original_source_code
+
+subsection('Billing Address')
+render_address(billing)
+
+subsection('Shipping Address')
+render_address(order.shipping)
+
+subsection('Items')
+(order.items || []).each do |item|
+  next if item.kit_component # skip kit components - they are sub-rows of a parent kit
+
+  qty  = item.quantity || 0
+  cost = item.cost || 0
+  printf(
+    "  %-12s %-32s qty %s @ %s = %s\n",
+    shorten(item.merchant_item_id || '', 12),
+    shorten(item.description || '', 32),
+    qty,
+    money(cost, order.currency_code),
+    money(qty * cost, order.currency_code)
+  )
+end
+
+if order.summary
+  puts
+  kv('Subtotal', money(order.summary.subtotal, order.currency_code))
+  kv('Tax',      money(order.summary.tax, order.currency_code))               unless order.summary.tax.nil?
+  kv('Shipping', money(order.summary.shipping_handling, order.currency_code)) unless order.summary.shipping_handling.nil?
+  kv('Total',    money(order.summary.total, order.currency_code))
+end
+
+subsection('Payment')
+payment = order.payment
+if payment
+  kv('Method', payment.payment_method)
+  cc = payment.credit_card
+  if cc
+    kv('Card', "#{cc.card_type || ''} ending #{cc.card_number_truncated || '????'}".strip)
+  end
+  transactions = payment.transactions || []
+  unless transactions.empty?
+    subsection('Transactions')
+    transactions.each do |tx|
+      status = tx.successful ? 'approved' : 'failed'
+      printf(
+        "  %-21s %-12s %-12s %s\n",
+        tx.dts || '',
+        tx.transaction_type || '',
+        money(tx.amount, order.currency_code),
+        status
+      )
+    end
+  end
+end
+
+subsection('Marketing / Attribution')
+utms = order.utms || []
+kv('Affiliate ID', marketing.affiliate_id || '(none)') if marketing
+if utms.empty?
+  puts '  No UTM clicks captured.'
+else
+  most_recent = utms[0] # index 0 is most recent click
+  kv('Most recent UTM source',   most_recent.utm_source)
+  kv('Most recent UTM medium',   most_recent.utm_medium)
+  kv('Most recent UTM campaign', most_recent.utm_campaign)
+  kv('UTM clicks captured', utms.length.to_s)
+end
+
+# Section 2: Subscription
+section('2. SUBSCRIPTION DETAILS')
+if auto_order.nil?
+  puts '  This order is NOT part of an auto order subscription.'
+else
+  puts '  This order IS part of an auto order subscription.'
+  puts
+  kv('Auto Order Code', auto_order.auto_order_code)
+  kv('Status',          auto_order.status)
+  kv('Enabled',         auto_order.enabled ? 'yes' : 'no')
+  kv('Original Order',  auto_order.original_order_id)
+  kv('Next Attempt',    auto_order.next_attempt || '(none scheduled)')
+  unless auto_order.canceled_dts.nil?
+    kv('Canceled',      auto_order.canceled_dts)
+    kv('Canceled By',   auto_order.canceled_by_user || '')
+    kv('Cancel Reason', auto_order.cancel_reason || '')
+  end
+  kv('Total Rebills', rebill_orders.length.to_s)
+
+  ao_items = auto_order.items || []
+  unless ao_items.empty?
+    subsection('Items in Subscription')
+    ao_items.each do |aoi|
+      printf(
+        "  %-12s %-32s frequency: %s\n",
+        shorten(aoi.original_item_id || '', 12),
+        shorten(aoi.original_item_id || '', 32),
+        aoi.frequency || ''
+      )
+    end
+  end
+
+  unless rebill_orders.empty?
+    subsection('Rebill Timeline')
+    rebill_orders.sort_by! { |r| r.creation_dts || '' }
+    rebill_orders.each do |ro|
+      ro_id    = ro.order_id || ''
+      marker   = ro_id.casecmp(order_id) == 0 ? '  *** THIS ORDER' : ''
+      ro_total = ro.summary ? money(ro.summary.total, ro.currency_code || 'USD') : ''
+      printf(
+        "  %-22s %-22s %-10s %s%s\n",
+        ro.creation_dts || '',
+        ro_id,
+        ro_total,
+        ro.current_stage || '',
+        marker
+      )
+    end
+  end
+
+  if auto_order_emails.empty?
+    subsection('Subscription-Level Emails')
+    puts '  No subscription-level emails on record.'
+  else
+    subsection("Subscription-Level Emails (#{auto_order_emails.length})")
+    auto_order_emails.each_with_index { |email, i| render_email_detail(i + 1, email) }
+  end
+end
+
+# Section 3: Emails
+section("3. EMAIL DELIVERY (#{emails.length} messages)")
+if emails.empty?
+  puts '  No email delivery records on file for this order.'
+else
+  emails.each_with_index { |email, i| render_email_detail(i + 1, email) }
+end
+
+# Section 4: Page view history
+section("4. PAGE VIEW HISTORY (#{page_views.length} views)")
+if page_view_is_redirected
+  puts '  Note: this is a subscription rebill. The disputed order itself has no'
+  puts '  checkout session of its own. The page views below are from the ORIGINAL'
+  puts '  order that started the subscription, where the customer\'s intent was'
+  puts '  captured during signup.'
+  puts
+  kv('Source order', page_view_order_id)
+end
+kv('Session referrer', session_referrer || '(direct or unknown)')
+
+if page_views.empty?
+  puts
+  puts "  No page views captured#{page_view_is_redirected ? ' for the original order.' : ' for this order session.'}"
+else
+  subsection('Timeline')
+  page_views.each do |pv|
+    top_s = pv.time_on_page.nil? ? '   -' : format('%4ds', pv.time_on_page)
+    printf("  %-22s %s   %s\n", pv.view_dts || '', top_s, pv.url || '')
+  end
+
+  if page_views.length >= 2
+    begin
+      first = DateTime.iso8601(page_views.first.view_dts)
+      last  = DateTime.iso8601(page_views.last.view_dts)
+      elapsed = ((last - first) * 24 * 60 * 60).to_i
+      if elapsed.positive?
+        mins = elapsed / 60
+        secs = elapsed % 60
+        puts
+        kv('Session length', "#{mins}m #{secs}s (first view to last view)")
+      end
+    rescue ArgumentError, TypeError
+      # ignore unparseable timestamps
+    end
+  end
+  unique_urls = page_views.map(&:url).compact.uniq
+  kv('Unique URLs visited', unique_urls.length.to_s)
+end
+
+puts
+hr('=')
+puts '  END OF EVIDENCE REPORT'
+hr('=')

--- a/ruby/order/get_chargeback_evidence.rb
+++ b/ruby/order/get_chargeback_evidence.rb
@@ -90,6 +90,14 @@ def kv(label, value, width = 22)
   puts "  #{(label + ':').ljust(width)} #{value || ''}"
 end
 
+# SDK money fields are Currency objects, not raw numbers. Pull the localized
+# value off; nil-safe for missing/optional fields.
+def money_value(currency)
+  return nil if currency.nil?
+
+  currency.respond_to?(:localized) ? currency.localized : nil
+end
+
 def money(amount, currency)
   return '' if amount.nil?
 
@@ -109,7 +117,7 @@ def render_address(addr)
   end
 
   name = [addr.first_name, addr.last_name].compact.join(' ').strip
-  city_row = [addr.city, addr.state].compact.reject(&:empty?).join(', ').strip
+  city_row = [addr.city, addr.state_region].compact.reject(&:empty?).join(', ').strip
   city_row = "#{city_row} #{addr.postal_code}".strip if addr.postal_code
 
   [name, addr.company, addr.address1, addr.address2, city_row, addr.country_code]
@@ -206,14 +214,15 @@ section('1. ORDER OVERVIEW')
 kv('Placed',   order.creation_dts)
 kv('Stage',    order.current_stage)
 kv('Currency', order.currency_code)
-kv('Order Total', money(order.summary.total, order.currency_code)) if order.summary
+kv('Order Total', money(money_value(order.summary.total), order.currency_code)) if order.summary
 
 subsection('Customer')
 billing = order.billing
 if billing
   kv('Name', [billing.first_name, billing.last_name].compact.join(' ').strip)
   kv('Email', billing.email)
-  kv('Phone', billing.phone)
+  # First populated phone wins
+  kv('Phone', billing.day_phone || billing.evening_phone || billing.cell_phone)
 end
 cp = order.customer_profile
 if cp
@@ -222,7 +231,8 @@ else
   kv('Customer Profile', 'no (guest checkout)')
 end
 marketing = order.marketing
-kv('Original Source', marketing.original_source_code) if marketing && marketing.original_source_code
+kv('Advertising Source', marketing.advertising_source) if marketing && marketing.respond_to?(:advertising_source) && marketing.advertising_source
+kv('Referral Code', marketing.referral_code)            if marketing && marketing.respond_to?(:referral_code)      && marketing.referral_code
 
 subsection('Billing Address')
 render_address(billing)
@@ -235,7 +245,7 @@ subsection('Items')
   next if item.kit_component # skip kit components - they are sub-rows of a parent kit
 
   qty  = item.quantity || 0
-  cost = item.cost || 0
+  cost = money_value(item.cost) || 0 # OrderItem.cost is a Currency object
   printf(
     "  %-12s %-32s qty %s @ %s = %s\n",
     shorten(item.merchant_item_id || '', 12),
@@ -248,10 +258,12 @@ end
 
 if order.summary
   puts
-  kv('Subtotal', money(order.summary.subtotal, order.currency_code))
-  kv('Tax',      money(order.summary.tax, order.currency_code))               unless order.summary.tax.nil?
-  kv('Shipping', money(order.summary.shipping_handling, order.currency_code)) unless order.summary.shipping_handling.nil?
-  kv('Total',    money(order.summary.total, order.currency_code))
+  kv('Subtotal', money(money_value(order.summary.subtotal), order.currency_code))
+  kv('Tax',      money(money_value(order.summary.tax), order.currency_code))                  unless order.summary.tax.nil?
+  if order.summary.respond_to?(:shipping_handling_total) && !order.summary.shipping_handling_total.nil?
+    kv('Shipping', money(money_value(order.summary.shipping_handling_total), order.currency_code))
+  end
+  kv('Total',    money(money_value(order.summary.total), order.currency_code))
 end
 
 subsection('Payment')
@@ -268,10 +280,9 @@ if payment
     transactions.each do |tx|
       status = tx.successful ? 'approved' : 'failed'
       printf(
-        "  %-21s %-12s %-12s %s\n",
-        tx.dts || '',
-        tx.transaction_type || '',
-        money(tx.amount, order.currency_code),
+        "  %-21s %-30s %s\n",
+        tx.transaction_timestamp || '',
+        shorten(tx.transaction_gateway || '', 30),
         status
       )
     end
@@ -280,7 +291,8 @@ end
 
 subsection('Marketing / Attribution')
 utms = order.utms || []
-kv('Affiliate ID', marketing.affiliate_id || '(none)') if marketing
+# Affiliate attribution lives on OrderAffiliate (expansion=affiliate); not pulled
+# here to keep the chargeback request light.
 if utms.empty?
   puts '  No UTM clicks captured.'
 else
@@ -329,7 +341,7 @@ else
     rebill_orders.each do |ro|
       ro_id    = ro.order_id || ''
       marker   = ro_id.casecmp(order_id) == 0 ? '  *** THIS ORDER' : ''
-      ro_total = ro.summary ? money(ro.summary.total, ro.currency_code || 'USD') : ''
+      ro_total = ro.summary ? money(money_value(ro.summary.total), ro.currency_code || 'USD') : ''
       printf(
         "  %-22s %-22s %-10s %s%s\n",
         ro.creation_dts || '',

--- a/typescript/order/GetChargebackEvidence.ts
+++ b/typescript/order/GetChargebackEvidence.ts
@@ -84,17 +84,17 @@ export class GetChargebackEvidence {
             let autoOrder: AutoOrder | undefined;
             let autoOrderEmails: AutoOrderEmail[] = [];
             let rebillOrders: Order[] = [];
-            const autoOrderPointer = order.autoOrder;
-            if (autoOrderPointer && autoOrderPointer.autoOrderOid !== undefined) {
-                const autoOrderOid = autoOrderPointer.autoOrderOid;
+            const autoOrderPointer = order.auto_order;
+            if (autoOrderPointer && autoOrderPointer.auto_order_oid !== undefined) {
+                const autoOrderOid = autoOrderPointer.auto_order_oid;
 
                 const aoResponse: AutoOrderResponse = await autoOrderApi.getAutoOrder({
                     autoOrderOid,
                     expand: autoOrderExpansion,
                 });
                 if (aoResponse.error) failOp('getAutoOrder', aoResponse.error);
-                autoOrder = aoResponse.autoOrder;
-                rebillOrders = autoOrder?.rebillOrders || [];
+                autoOrder = aoResponse.auto_order;
+                rebillOrders = autoOrder?.rebill_orders || [];
 
                 const aoEmailsResponse: AutoOrderEmailsResponse = await autoOrderApi.getAutoOrderEmails({ autoOrderOid });
                 if (aoEmailsResponse.error) failOp('getAutoOrderEmails', aoEmailsResponse.error);
@@ -105,16 +105,16 @@ export class GetChargebackEvidence {
             let pageViewOrderId = orderId;
             let pageViewIsRedirected = false;
             if (autoOrder &&
-                autoOrder.originalOrderId &&
-                autoOrder.originalOrderId.toLowerCase() !== orderId.toLowerCase()) {
-                pageViewOrderId = autoOrder.originalOrderId;
+                autoOrder.original_order_id &&
+                autoOrder.original_order_id.toLowerCase() !== orderId.toLowerCase()) {
+                pageViewOrderId = autoOrder.original_order_id;
                 pageViewIsRedirected = true;
             }
 
             const pageViewResponse: OrderPageViewHistoryResponse =
                 await orderApi.getOrderPageViewHistory({ orderId: pageViewOrderId });
             if (pageViewResponse.error) failOp('getOrderPageViewHistory', pageViewResponse.error);
-            const pageViews: OrderPageView[] = pageViewResponse.pageViews || [];
+            const pageViews: OrderPageView[] = pageViewResponse.page_views || [];
             const sessionReferrer = pageViewResponse.referrer;
 
             renderHeader(orderId);
@@ -147,22 +147,24 @@ function renderHeader(orderId: string): void {
 function renderOrderOverview(order: Order): void {
     section('1. ORDER OVERVIEW');
 
-    kv('Placed',   order.creationDts);
-    kv('Stage',    order.currentStage);
-    kv('Currency', order.currencyCode);
-    if (order.summary) kv('Order Total', money(order.summary.total, order.currencyCode));
+    kv('Placed',   order.creation_dts);
+    kv('Stage',    order.current_stage);
+    kv('Currency', order.currency_code);
+    if (order.summary) kv('Order Total', money(moneyValue(order.summary.total), order.currency_code));
 
     subsection('Customer');
     const billing = order.billing;
     if (billing) {
-        kv('Name',  [billing.firstName, billing.lastName].filter(Boolean).join(' ').trim());
+        kv('Name',  [billing.first_name, billing.last_name].filter(Boolean).join(' ').trim());
         kv('Email', billing.email);
-        kv('Phone', billing.phone);
+        // First populated phone wins - billing has separate day/evening/cell fields
+        kv('Phone', billing.day_phone || billing.evening_phone || billing.cell_phone);
     }
-    const cp = order.customerProfile;
-    kv('Customer Profile', cp ? `yes (oid ${cp.customerProfileOid ?? '?'})` : 'no (guest checkout)');
+    const cp = order.customer_profile;
+    kv('Customer Profile', cp ? `yes (oid ${cp.customer_profile_oid ?? '?'})` : 'no (guest checkout)');
     const marketing = order.marketing;
-    if (marketing && marketing.originalSourceCode) kv('Original Source', marketing.originalSourceCode);
+    if (marketing && marketing.advertising_source) kv('Advertising Source', marketing.advertising_source);
+    if (marketing && marketing.referral_code) kv('Referral Code', marketing.referral_code);
 
     subsection('Billing Address');
     renderAddress(billing);
@@ -172,40 +174,37 @@ function renderOrderOverview(order: Order): void {
 
     subsection('Items');
     for (const item of (order.items || [])) {
-        if (item.kitComponent) continue; // skip kit components
+        if (item.kit_component) continue; // skip kit components
         const qty  = item.quantity ?? 0;
-        const cost = item.cost ?? 0;
+        const cost = moneyValue(item.cost) ?? 0; // OrderItem.cost is a Currency object
         console.log(
-            '  ' + pad(shorten(item.merchantItemId || '', 12), 12) + ' ' +
+            '  ' + pad(shorten(item.merchant_item_id || '', 12), 12) + ' ' +
             pad(shorten(item.description || '', 32), 32) +
-            ` qty ${qty} @ ${money(cost, order.currencyCode)} = ${money(qty * cost, order.currencyCode)}`
+            ` qty ${qty} @ ${money(cost, order.currency_code)} = ${money(qty * cost, order.currency_code)}`
         );
     }
 
     if (order.summary) {
         console.log();
-        kv('Subtotal', money(order.summary.subtotal, order.currencyCode));
-        if (order.summary.tax !== null && order.summary.tax !== undefined)
-            kv('Tax',      money(order.summary.tax, order.currencyCode));
-        if (order.summary.shippingHandling !== null && order.summary.shippingHandling !== undefined)
-            kv('Shipping', money(order.summary.shippingHandling, order.currencyCode));
-        kv('Total',    money(order.summary.total, order.currencyCode));
+        kv('Subtotal', money(moneyValue(order.summary.subtotal), order.currency_code));
+        if (order.summary.tax)                     kv('Tax',      money(moneyValue(order.summary.tax), order.currency_code));
+        if (order.summary.shipping_handling_total) kv('Shipping', money(moneyValue(order.summary.shipping_handling_total), order.currency_code));
+        kv('Total',    money(moneyValue(order.summary.total), order.currency_code));
     }
 
     subsection('Payment');
     const payment = order.payment;
     if (payment) {
-        kv('Method', payment.paymentMethod);
-        const cc = payment.creditCard;
-        if (cc) kv('Card', `${cc.cardType || ''} ending ${cc.cardNumberTruncated || '????'}`.trim());
+        kv('Method', payment.payment_method);
+        const cc = payment.credit_card;
+        if (cc) kv('Card', `${cc.card_type || ''} ending ${cc.card_number_truncated || '????'}`.trim());
         const transactions = payment.transactions || [];
         if (transactions.length) {
             subsection('Transactions');
             for (const tx of transactions) {
                 console.log(
-                    '  ' + pad(tx.dts || '', 21) + ' ' +
-                    pad(tx.transactionType || '', 12) + ' ' +
-                    pad(money(tx.amount, order.currencyCode), 12) + ' ' +
+                    '  ' + pad(tx.transaction_timestamp || '', 21) + ' ' +
+                    pad(shorten(tx.transaction_gateway || '', 30), 30) + ' ' +
                     (tx.successful ? 'approved' : 'failed')
                 );
             }
@@ -214,14 +213,15 @@ function renderOrderOverview(order: Order): void {
 
     subsection('Marketing / Attribution');
     const utms = order.utms || [];
-    if (marketing) kv('Affiliate ID', marketing.affiliateId !== undefined && marketing.affiliateId !== null ? String(marketing.affiliateId) : '(none)');
+    // Affiliate attribution lives on OrderAffiliate (expansion=affiliate); not pulled
+    // here to keep the chargeback request light.
     if (utms.length === 0) {
         console.log('  No UTM clicks captured.');
     } else {
         const mostRecent = utms[0]; // index 0 is most recent click
-        kv('Most recent UTM source',   mostRecent.utmSource);
-        kv('Most recent UTM medium',   mostRecent.utmMedium);
-        kv('Most recent UTM campaign', mostRecent.utmCampaign);
+        kv('Most recent UTM source',   mostRecent.utm_source);
+        kv('Most recent UTM medium',   mostRecent.utm_medium);
+        kv('Most recent UTM campaign', mostRecent.utm_campaign);
         kv('UTM clicks captured', String(utms.length));
     }
 }
@@ -241,15 +241,15 @@ function renderSubscription(
 
     console.log('  This order IS part of an auto order subscription.');
     console.log();
-    kv('Auto Order Code', autoOrder.autoOrderCode);
+    kv('Auto Order Code', autoOrder.auto_order_code);
     kv('Status',          autoOrder.status);
     kv('Enabled',         autoOrder.enabled ? 'yes' : 'no');
-    kv('Original Order',  autoOrder.originalOrderId);
-    kv('Next Attempt',    autoOrder.nextAttempt || '(none scheduled)');
-    if (autoOrder.canceledDts) {
-        kv('Canceled',      autoOrder.canceledDts);
-        kv('Canceled By',   autoOrder.canceledByUser || '');
-        kv('Cancel Reason', autoOrder.cancelReason || '');
+    kv('Original Order',  autoOrder.original_order_id);
+    kv('Next Attempt',    autoOrder.next_attempt || '(none scheduled)');
+    if (autoOrder.canceled_dts) {
+        kv('Canceled',      autoOrder.canceled_dts);
+        kv('Canceled By',   autoOrder.canceled_by_user || '');
+        kv('Cancel Reason', autoOrder.cancel_reason || '');
     }
     kv('Total Rebills', String(rebillOrders.length));
 
@@ -258,8 +258,8 @@ function renderSubscription(
         subsection('Items in Subscription');
         for (const aoi of aoItems) {
             console.log(
-                '  ' + pad(shorten(aoi.originalItemId || '', 12), 12) + ' ' +
-                pad(shorten(aoi.originalItemId || '', 32), 32) +
+                '  ' + pad(shorten(aoi.original_item_id || '', 12), 12) + ' ' +
+                pad(shorten(aoi.original_item_id || '', 32), 32) +
                 ` frequency: ${aoi.frequency || ''}`
             );
         }
@@ -267,16 +267,16 @@ function renderSubscription(
 
     if (rebillOrders.length) {
         subsection('Rebill Timeline');
-        rebillOrders.sort((a, b) => (a.creationDts || '').localeCompare(b.creationDts || ''));
+        rebillOrders.sort((a, b) => (a.creation_dts || '').localeCompare(b.creation_dts || ''));
         for (const ro of rebillOrders) {
-            const roId    = ro.orderId || '';
+            const roId    = ro.order_id || '';
             const marker  = roId.toLowerCase() === currentOrderId.toLowerCase() ? '  *** THIS ORDER' : '';
-            const roTotal = ro.summary ? money(ro.summary.total, ro.currencyCode || 'USD') : '';
+            const roTotal = ro.summary ? money(moneyValue(ro.summary.total), ro.currency_code || 'USD') : '';
             console.log(
-                '  ' + pad(ro.creationDts || '', 22) + ' ' +
+                '  ' + pad(ro.creation_dts || '', 22) + ' ' +
                 pad(roId, 22) + ' ' +
                 pad(roTotal, 10) + ' ' +
-                (ro.currentStage || '') + marker
+                (ro.current_stage || '') + marker
             );
         }
     }
@@ -301,24 +301,24 @@ function renderEmails(emails: OrderEmail[]): void {
 
 function renderEmailDetail(i: number, email: OrderEmail | AutoOrderEmail): void {
     const internal = email.internal ? '   (internal copy)' : '';
-    console.log(`  [${i}] sent ${email.sendDts || '?'}${internal}`);
+    console.log(`  [${i}] sent ${email.send_dts || '?'}${internal}`);
     console.log(`      To:               ${email.email || ''}`);
     console.log(`      Subject:          ${email.subject || ''}`);
 
     const states: string[] = [];
     if (email.delivered)              states.push('DELIVERED');
     if (email.skipped)                states.push('SKIPPED');
-    if (email.bounceDts)              states.push(`BOUNCED ${email.bounceDts}`);
-    if (email.opened)                 states.push(`OPENED ${email.openedDts || ''}`);
-    if (email.clicked)                states.push(`CLICKED ${email.clickedDts || ''}`);
+    if (email.bounce_dts)             states.push(`BOUNCED ${email.bounce_dts}`);
+    if (email.opened)                 states.push(`OPENED ${email.opened_dts || ''}`);
+    if (email.clicked)                states.push(`CLICKED ${email.clicked_dts || ''}`);
     console.log(`      Status:           ${states.length ? states.join(', ') : 'unknown'}`);
 
-    if (email.deliveryDts)           console.log(`      Delivered:        ${email.deliveryDts}`);
-    if (email.reportingMta)          console.log(`      Reporting MTA:    ${email.reportingMta}`);
-    if (email.smtpResponse)          console.log(`      SMTP response:    ${email.smtpResponse}`);
-    if (email.bounceType)            console.log(`      Bounce type:      ${email.bounceType} / ${email.bounceSubType || ''}`);
-    if (email.bounceDiagnosticCode)  console.log(`      Diagnostic:       ${email.bounceDiagnosticCode}`);
-    if (email.skipReason)            console.log(`      Skip reason:      ${email.skipReason}`);
+    if (email.delivery_dts)           console.log(`      Delivered:        ${email.delivery_dts}`);
+    if (email.reporting_mta)          console.log(`      Reporting MTA:    ${email.reporting_mta}`);
+    if (email.smtp_response)          console.log(`      SMTP response:    ${email.smtp_response}`);
+    if (email.bounce_type)            console.log(`      Bounce type:      ${email.bounce_type} / ${email.bounce_sub_type || ''}`);
+    if (email.bounce_diagnostic_code) console.log(`      Diagnostic:       ${email.bounce_diagnostic_code}`);
+    if (email.skip_reason)            console.log(`      Skip reason:      ${email.skip_reason}`);
     console.log();
 }
 
@@ -347,14 +347,14 @@ function renderPageViewHistory(
 
     subsection('Timeline');
     for (const pv of pageViews) {
-        const top  = pv.timeOnPage;
+        const top  = pv.time_on_page;
         const tops = top === null || top === undefined ? '   -' : String(top).padStart(4, ' ') + 's';
-        console.log(`  ${pad(pv.viewDts || '', 22)} ${tops}   ${pv.url || ''}`);
+        console.log(`  ${pad(pv.view_dts || '', 22)} ${tops}   ${pv.url || ''}`);
     }
 
     if (pageViews.length >= 2) {
-        const first = Date.parse(pageViews[0].viewDts || '');
-        const last  = Date.parse(pageViews[pageViews.length - 1].viewDts || '');
+        const first = Date.parse(pageViews[0].view_dts || '');
+        const last  = Date.parse(pageViews[pageViews.length - 1].view_dts || '');
         if (!isNaN(first) && !isNaN(last) && last > first) {
             const elapsed = Math.floor((last - first) / 1000);
             const mins = Math.floor(elapsed / 60);
@@ -370,13 +370,13 @@ function renderPageViewHistory(
 
 function renderAddress(address: any): void {
     if (!address) { console.log('  (none on file)'); return; }
-    const name    = [address.firstName, address.lastName].filter(Boolean).join(' ').trim();
+    const name    = [address.first_name, address.last_name].filter(Boolean).join(' ').trim();
     const cityRow = (
         (address.city || '') +
-        (address.state ? `, ${address.state}` : '') +
-        ' ' + (address.postalCode || '')
+        (address.state_region ? `, ${address.state_region}` : '') +
+        ' ' + (address.postal_code || '')
     ).trim();
-    [name, address.company, address.address1, address.address2, cityRow, address.countryCode]
+    [name, address.company, address.address1, address.address2, cityRow, address.country_code]
         .filter((line: string) => line && line.trim().length > 0)
         .forEach((line: string) => console.log(`  ${line}`));
 }
@@ -399,6 +399,13 @@ function kv(label: string, value: any, width = 22): void {
 }
 function pad(s: any, n: number): string { const v = s == null ? '' : String(s); return v.length >= n ? v : v + ' '.repeat(n - v.length); }
 function shorten(s: any, n: number): string { const v = s == null ? '' : String(s); return v.length <= n ? v : v.substring(0, n - 1) + '~'; }
+// SDK money fields are Currency objects, not raw numbers. Pull the localized
+// value off; null-safe for missing/optional fields.
+function moneyValue(currency: any): number | undefined {
+    if (currency === null || currency === undefined) return undefined;
+    return currency.localized;
+}
+
 function money(amount: number | null | undefined, currency: string | null | undefined): string {
     if (amount === null || amount === undefined) return '';
     const sign = amount < 0 ? '-' : '';
@@ -407,7 +414,7 @@ function money(amount: number | null | undefined, currency: string | null | unde
 
 function failOp(operation: string, error: any): never {
     console.error(`ERROR in ${operation}:`);
-    console.error(`  Developer message: ${error.developerMessage || error.developer_message || ''}`);
-    console.error(`  User message:      ${error.userMessage      || error.user_message      || ''}`);
+    console.error(`  Developer message: ${error.developer_message || ''}`);
+    console.error(`  User message:      ${error.user_message      || ''}`);
     process.exit(1);
 }

--- a/typescript/order/GetChargebackEvidence.ts
+++ b/typescript/order/GetChargebackEvidence.ts
@@ -1,0 +1,413 @@
+import { orderApi, autoOrderApi } from '../api';
+import {
+    Order,
+    OrderResponse,
+    OrderEmail,
+    OrderEmailsResponse,
+    OrderPageView,
+    OrderPageViewHistoryResponse,
+    AutoOrder,
+    AutoOrderResponse,
+    AutoOrderEmail,
+    AutoOrderEmailsResponse,
+} from 'ultracart_rest_api_v2_typescript';
+
+/**
+ * GetChargebackEvidence
+ *
+ * Pulls everything from UltraCart that is useful when fighting a chargeback
+ * dispute and prints a formatted evidence report. Designed as a starting point
+ * for building the actual evidence packet you submit to the card processor.
+ *
+ * What this sample demonstrates:
+ *   1. Order detail with the SPECIFIC expansions a chargeback case relies on.
+ *      Notice we list every expansion explicitly - no shortcuts. Listing them
+ *      individually keeps your payload small and forces you to think about
+ *      what evidence each one represents.
+ *   2. Email delivery records via the dedicated /emails endpoint (not via
+ *      expansion). Use the dedicated endpoint for chargeback work - it is the
+ *      canonical full-fidelity source for SES delivery events on every order.
+ *   3. Page view history (the customer was on your site, navigated through
+ *      pages, spent time before placing the order).
+ *   4. Auto-order detection: a large fraction of chargebacks are subscription
+ *      disputes. When the order is part of an auto order, the sample pulls
+ *      the parent subscription, every rebill, and the auto-order-level email
+ *      log. For rebills specifically, the page-view lookup pivots to the
+ *      ORIGINAL order (the rebill itself has no checkout session).
+ *
+ * Run:
+ *   NODE_TLS_REJECT_UNAUTHORIZED=0 node order/GetChargebackEvidence.js DEMO-0009104976
+ *
+ * Requires the May 2026 SDK build with getOrderEmails,
+ * getOrderPageViewHistory, and getAutoOrderEmails.
+ */
+export class GetChargebackEvidence {
+    public static async execute(): Promise<void> {
+        const orderId = process.argv[2] || 'DEMO-0009104976';
+
+        // Listing expansions individually keeps payload size predictable and
+        // makes it obvious what evidence each piece is providing.
+        const orderExpansion = [
+            'billing',
+            'shipping',
+            'payment',
+            'payment.transaction',
+            'summary',
+            'items',
+            'coupon',
+            'customer_profile',
+            'auto_order',
+            'utms',
+            'marketing',
+            'gift',
+            'point_of_sale',
+            'channel_partner',
+        ].join(',');
+
+        const autoOrderExpansion = ['items', 'rebill_orders', 'logs', 'management'].join(',');
+
+        try {
+            // Order detail
+            const orderResponse: OrderResponse = await orderApi.getOrder({ orderId, expand: orderExpansion });
+            if (orderResponse.error) failOp('getOrder', orderResponse.error);
+            const order = orderResponse.order!;
+
+            // Use the dedicated /emails endpoint rather than _expand=emails. The
+            // dedicated endpoint is the canonical full-fidelity source for SES
+            // delivery events.
+            const emailsResponse: OrderEmailsResponse = await orderApi.getOrderEmails({ orderId });
+            if (emailsResponse.error) failOp('getOrderEmails', emailsResponse.error);
+            const emails: OrderEmail[] = emailsResponse.emails || [];
+
+            // Auto-order chain BEFORE page views: a rebill's own page view history
+            // is empty - the meaningful history lives on the original order.
+            let autoOrder: AutoOrder | undefined;
+            let autoOrderEmails: AutoOrderEmail[] = [];
+            let rebillOrders: Order[] = [];
+            const autoOrderPointer = order.autoOrder;
+            if (autoOrderPointer && autoOrderPointer.autoOrderOid !== undefined) {
+                const autoOrderOid = autoOrderPointer.autoOrderOid;
+
+                const aoResponse: AutoOrderResponse = await autoOrderApi.getAutoOrder({
+                    autoOrderOid,
+                    expand: autoOrderExpansion,
+                });
+                if (aoResponse.error) failOp('getAutoOrder', aoResponse.error);
+                autoOrder = aoResponse.autoOrder;
+                rebillOrders = autoOrder?.rebillOrders || [];
+
+                const aoEmailsResponse: AutoOrderEmailsResponse = await autoOrderApi.getAutoOrderEmails({ autoOrderOid });
+                if (aoEmailsResponse.error) failOp('getAutoOrderEmails', aoEmailsResponse.error);
+                autoOrderEmails = aoEmailsResponse.emails || [];
+            }
+
+            // For a rebill chargeback, page views live on the ORIGINAL order.
+            let pageViewOrderId = orderId;
+            let pageViewIsRedirected = false;
+            if (autoOrder &&
+                autoOrder.originalOrderId &&
+                autoOrder.originalOrderId.toLowerCase() !== orderId.toLowerCase()) {
+                pageViewOrderId = autoOrder.originalOrderId;
+                pageViewIsRedirected = true;
+            }
+
+            const pageViewResponse: OrderPageViewHistoryResponse =
+                await orderApi.getOrderPageViewHistory({ orderId: pageViewOrderId });
+            if (pageViewResponse.error) failOp('getOrderPageViewHistory', pageViewResponse.error);
+            const pageViews: OrderPageView[] = pageViewResponse.pageViews || [];
+            const sessionReferrer = pageViewResponse.referrer;
+
+            renderHeader(orderId);
+            renderOrderOverview(order);
+            renderSubscription(autoOrder, rebillOrders, orderId, autoOrderEmails);
+            renderEmails(emails);
+            renderPageViewHistory(pageViews, sessionReferrer, pageViewOrderId, pageViewIsRedirected);
+            renderFooter();
+        } catch (error) {
+            console.error('Error gathering chargeback evidence:', error);
+            process.exit(1);
+        }
+    }
+}
+
+// =====================================================================
+// Render helpers
+// =====================================================================
+
+function renderHeader(orderId: string): void {
+    hr('=');
+    console.log('  CHARGEBACK EVIDENCE REPORT');
+    console.log('  UltraCart REST API v2');
+    hr('=');
+    console.log();
+    kv('Order ID',  orderId);
+    kv('Generated', new Date().toISOString());
+}
+
+function renderOrderOverview(order: Order): void {
+    section('1. ORDER OVERVIEW');
+
+    kv('Placed',   order.creationDts);
+    kv('Stage',    order.currentStage);
+    kv('Currency', order.currencyCode);
+    if (order.summary) kv('Order Total', money(order.summary.total, order.currencyCode));
+
+    subsection('Customer');
+    const billing = order.billing;
+    if (billing) {
+        kv('Name',  [billing.firstName, billing.lastName].filter(Boolean).join(' ').trim());
+        kv('Email', billing.email);
+        kv('Phone', billing.phone);
+    }
+    const cp = order.customerProfile;
+    kv('Customer Profile', cp ? `yes (oid ${cp.customerProfileOid ?? '?'})` : 'no (guest checkout)');
+    const marketing = order.marketing;
+    if (marketing && marketing.originalSourceCode) kv('Original Source', marketing.originalSourceCode);
+
+    subsection('Billing Address');
+    renderAddress(billing);
+
+    subsection('Shipping Address');
+    renderAddress(order.shipping);
+
+    subsection('Items');
+    for (const item of (order.items || [])) {
+        if (item.kitComponent) continue; // skip kit components
+        const qty  = item.quantity ?? 0;
+        const cost = item.cost ?? 0;
+        console.log(
+            '  ' + pad(shorten(item.merchantItemId || '', 12), 12) + ' ' +
+            pad(shorten(item.description || '', 32), 32) +
+            ` qty ${qty} @ ${money(cost, order.currencyCode)} = ${money(qty * cost, order.currencyCode)}`
+        );
+    }
+
+    if (order.summary) {
+        console.log();
+        kv('Subtotal', money(order.summary.subtotal, order.currencyCode));
+        if (order.summary.tax !== null && order.summary.tax !== undefined)
+            kv('Tax',      money(order.summary.tax, order.currencyCode));
+        if (order.summary.shippingHandling !== null && order.summary.shippingHandling !== undefined)
+            kv('Shipping', money(order.summary.shippingHandling, order.currencyCode));
+        kv('Total',    money(order.summary.total, order.currencyCode));
+    }
+
+    subsection('Payment');
+    const payment = order.payment;
+    if (payment) {
+        kv('Method', payment.paymentMethod);
+        const cc = payment.creditCard;
+        if (cc) kv('Card', `${cc.cardType || ''} ending ${cc.cardNumberTruncated || '????'}`.trim());
+        const transactions = payment.transactions || [];
+        if (transactions.length) {
+            subsection('Transactions');
+            for (const tx of transactions) {
+                console.log(
+                    '  ' + pad(tx.dts || '', 21) + ' ' +
+                    pad(tx.transactionType || '', 12) + ' ' +
+                    pad(money(tx.amount, order.currencyCode), 12) + ' ' +
+                    (tx.successful ? 'approved' : 'failed')
+                );
+            }
+        }
+    }
+
+    subsection('Marketing / Attribution');
+    const utms = order.utms || [];
+    if (marketing) kv('Affiliate ID', marketing.affiliateId !== undefined && marketing.affiliateId !== null ? String(marketing.affiliateId) : '(none)');
+    if (utms.length === 0) {
+        console.log('  No UTM clicks captured.');
+    } else {
+        const mostRecent = utms[0]; // index 0 is most recent click
+        kv('Most recent UTM source',   mostRecent.utmSource);
+        kv('Most recent UTM medium',   mostRecent.utmMedium);
+        kv('Most recent UTM campaign', mostRecent.utmCampaign);
+        kv('UTM clicks captured', String(utms.length));
+    }
+}
+
+function renderSubscription(
+    autoOrder: AutoOrder | undefined,
+    rebillOrders: Order[],
+    currentOrderId: string,
+    autoOrderEmails: AutoOrderEmail[]
+): void {
+    section('2. SUBSCRIPTION DETAILS');
+
+    if (!autoOrder) {
+        console.log('  This order is NOT part of an auto order subscription.');
+        return;
+    }
+
+    console.log('  This order IS part of an auto order subscription.');
+    console.log();
+    kv('Auto Order Code', autoOrder.autoOrderCode);
+    kv('Status',          autoOrder.status);
+    kv('Enabled',         autoOrder.enabled ? 'yes' : 'no');
+    kv('Original Order',  autoOrder.originalOrderId);
+    kv('Next Attempt',    autoOrder.nextAttempt || '(none scheduled)');
+    if (autoOrder.canceledDts) {
+        kv('Canceled',      autoOrder.canceledDts);
+        kv('Canceled By',   autoOrder.canceledByUser || '');
+        kv('Cancel Reason', autoOrder.cancelReason || '');
+    }
+    kv('Total Rebills', String(rebillOrders.length));
+
+    const aoItems = autoOrder.items || [];
+    if (aoItems.length) {
+        subsection('Items in Subscription');
+        for (const aoi of aoItems) {
+            console.log(
+                '  ' + pad(shorten(aoi.originalItemId || '', 12), 12) + ' ' +
+                pad(shorten(aoi.originalItemId || '', 32), 32) +
+                ` frequency: ${aoi.frequency || ''}`
+            );
+        }
+    }
+
+    if (rebillOrders.length) {
+        subsection('Rebill Timeline');
+        rebillOrders.sort((a, b) => (a.creationDts || '').localeCompare(b.creationDts || ''));
+        for (const ro of rebillOrders) {
+            const roId    = ro.orderId || '';
+            const marker  = roId.toLowerCase() === currentOrderId.toLowerCase() ? '  *** THIS ORDER' : '';
+            const roTotal = ro.summary ? money(ro.summary.total, ro.currencyCode || 'USD') : '';
+            console.log(
+                '  ' + pad(ro.creationDts || '', 22) + ' ' +
+                pad(roId, 22) + ' ' +
+                pad(roTotal, 10) + ' ' +
+                (ro.currentStage || '') + marker
+            );
+        }
+    }
+
+    if (autoOrderEmails.length) {
+        subsection(`Subscription-Level Emails (${autoOrderEmails.length})`);
+        autoOrderEmails.forEach((email, i) => renderEmailDetail(i + 1, email));
+    } else {
+        subsection('Subscription-Level Emails');
+        console.log('  No subscription-level emails on record.');
+    }
+}
+
+function renderEmails(emails: OrderEmail[]): void {
+    section(`3. EMAIL DELIVERY (${emails.length} messages)`);
+    if (emails.length === 0) {
+        console.log('  No email delivery records on file for this order.');
+        return;
+    }
+    emails.forEach((email, i) => renderEmailDetail(i + 1, email));
+}
+
+function renderEmailDetail(i: number, email: OrderEmail | AutoOrderEmail): void {
+    const internal = email.internal ? '   (internal copy)' : '';
+    console.log(`  [${i}] sent ${email.sendDts || '?'}${internal}`);
+    console.log(`      To:               ${email.email || ''}`);
+    console.log(`      Subject:          ${email.subject || ''}`);
+
+    const states: string[] = [];
+    if (email.delivered)              states.push('DELIVERED');
+    if (email.skipped)                states.push('SKIPPED');
+    if (email.bounceDts)              states.push(`BOUNCED ${email.bounceDts}`);
+    if (email.opened)                 states.push(`OPENED ${email.openedDts || ''}`);
+    if (email.clicked)                states.push(`CLICKED ${email.clickedDts || ''}`);
+    console.log(`      Status:           ${states.length ? states.join(', ') : 'unknown'}`);
+
+    if (email.deliveryDts)           console.log(`      Delivered:        ${email.deliveryDts}`);
+    if (email.reportingMta)          console.log(`      Reporting MTA:    ${email.reportingMta}`);
+    if (email.smtpResponse)          console.log(`      SMTP response:    ${email.smtpResponse}`);
+    if (email.bounceType)            console.log(`      Bounce type:      ${email.bounceType} / ${email.bounceSubType || ''}`);
+    if (email.bounceDiagnosticCode)  console.log(`      Diagnostic:       ${email.bounceDiagnosticCode}`);
+    if (email.skipReason)            console.log(`      Skip reason:      ${email.skipReason}`);
+    console.log();
+}
+
+function renderPageViewHistory(
+    pageViews: OrderPageView[],
+    sessionReferrer: string | undefined,
+    sourceOrderId: string,
+    isRedirected: boolean
+): void {
+    section(`4. PAGE VIEW HISTORY (${pageViews.length} views)`);
+    if (isRedirected) {
+        console.log("  Note: this is a subscription rebill. The disputed order itself has no");
+        console.log("  checkout session of its own. The page views below are from the ORIGINAL");
+        console.log("  order that started the subscription, where the customer's intent was");
+        console.log("  captured during signup.");
+        console.log();
+        kv('Source order', sourceOrderId);
+    }
+    kv('Session referrer', sessionReferrer || '(direct or unknown)');
+
+    if (pageViews.length === 0) {
+        console.log();
+        console.log(`  No page views captured${isRedirected ? ' for the original order.' : " for this order's session."}`);
+        return;
+    }
+
+    subsection('Timeline');
+    for (const pv of pageViews) {
+        const top  = pv.timeOnPage;
+        const tops = top === null || top === undefined ? '   -' : String(top).padStart(4, ' ') + 's';
+        console.log(`  ${pad(pv.viewDts || '', 22)} ${tops}   ${pv.url || ''}`);
+    }
+
+    if (pageViews.length >= 2) {
+        const first = Date.parse(pageViews[0].viewDts || '');
+        const last  = Date.parse(pageViews[pageViews.length - 1].viewDts || '');
+        if (!isNaN(first) && !isNaN(last) && last > first) {
+            const elapsed = Math.floor((last - first) / 1000);
+            const mins = Math.floor(elapsed / 60);
+            const secs = elapsed % 60;
+            console.log();
+            kv('Session length', `${mins}m ${secs}s (first view to last view)`);
+        }
+    }
+
+    const uniqueUrls = new Set(pageViews.map(pv => pv.url).filter(Boolean));
+    kv('Unique URLs visited', String(uniqueUrls.size));
+}
+
+function renderAddress(address: any): void {
+    if (!address) { console.log('  (none on file)'); return; }
+    const name    = [address.firstName, address.lastName].filter(Boolean).join(' ').trim();
+    const cityRow = (
+        (address.city || '') +
+        (address.state ? `, ${address.state}` : '') +
+        ' ' + (address.postalCode || '')
+    ).trim();
+    [name, address.company, address.address1, address.address2, cityRow, address.countryCode]
+        .filter((line: string) => line && line.trim().length > 0)
+        .forEach((line: string) => console.log(`  ${line}`));
+}
+
+function renderFooter(): void {
+    console.log();
+    hr('=');
+    console.log('  END OF EVIDENCE REPORT');
+    hr('=');
+}
+
+// =====================================================================
+// Tiny formatting primitives
+// =====================================================================
+function hr(char: string): void { console.log(char.repeat(80)); }
+function section(title: string):    void { console.log(); hr('='); console.log(`  ${title}`); hr('='); console.log(); }
+function subsection(title: string): void { console.log(); console.log(`  ${title}`); console.log('  ' + '-'.repeat(title.length)); }
+function kv(label: string, value: any, width = 22): void {
+    console.log(`  ${(label + ':').padEnd(width)} ${value === null || value === undefined ? '' : value}`);
+}
+function pad(s: any, n: number): string { const v = s == null ? '' : String(s); return v.length >= n ? v : v + ' '.repeat(n - v.length); }
+function shorten(s: any, n: number): string { const v = s == null ? '' : String(s); return v.length <= n ? v : v.substring(0, n - 1) + '~'; }
+function money(amount: number | null | undefined, currency: string | null | undefined): string {
+    if (amount === null || amount === undefined) return '';
+    const sign = amount < 0 ? '-' : '';
+    return `${sign}$${Math.abs(amount).toFixed(2)} ${currency || ''}`.trim();
+}
+
+function failOp(operation: string, error: any): never {
+    console.error(`ERROR in ${operation}:`);
+    console.error(`  Developer message: ${error.developerMessage || error.developer_message || ''}`);
+    console.error(`  User message:      ${error.userMessage      || error.user_message      || ''}`);
+    process.exit(1);
+}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -7,7 +7,7 @@
     "@types/node": "^16.18.126",
     "luxon": "2.5.2",
     "typescript": "^4.9.5",
-    "ultracart_rest_api_v2_typescript": "4.1.15",
+    "ultracart_rest_api_v2_typescript": "4.1.88",
     "uuid": "^11.1.0"
   },
   "author": "UltraCart",


### PR DESCRIPTION
## Summary

- New ``getChargebackEvidence`` sample across all 7 language directories that pulls every UltraCart data point useful for fighting a chargeback dispute and prints a sectioned plain-text evidence report
- Exercises three new endpoints from the May 2026 API release: ``getOrderEmails``, ``getOrderPageViewHistory``, ``getAutoOrderEmails``
- Bumps the UltraCart SDK pin to 4.1.88 in PHP, Ruby, JavaScript, TypeScript, and C# (Java stays on 4.1.15 — Maven Central still on 4.1.13 at time of this PR)

## What the sample does

Given an ``order_id``, it pulls and renders:

1. **Order detail** with an explicit expansion list (``billing, shipping, payment, payment.transaction, summary, items, coupon, customer_profile, auto_order, utms, marketing, gift, point_of_sale, channel_partner``). Listed individually rather than via a catch-all so the developer sees the menu of evidence pieces and can drop what they don't need.
2. **Email delivery records** via the dedicated ``/emails`` endpoint (not via expansion) — this is the canonical full-fidelity source for SES delivery events.
3. **Page view history** via the dedicated endpoint, with an important pivot: **for subscription rebill chargebacks, the lookup automatically redirects to the ORIGINAL order's session** (the rebill itself never had a checkout, so its page view history is empty).
4. **Auto-order chain** when applicable: parent subscription + every rebill + the auto-order-level email log. The rebill timeline marks ``*** THIS ORDER`` so the disputed rebill stands out in the chain.

Items in the report skip kit components (sub-rows of a parent kit), keeping the evidence focused on what the customer actually paid for.

## Validation

| Language | Method | Result |
|---|---|---|
| PHP | reflection check + reaches HTTP layer against 4.1.88 | clean |
| TypeScript | ``tsc --noEmit`` against 4.1.88 types | clean compile |
| Python | ``py_compile`` + ``hasattr`` checks against 4.1.88 | clean |
| Ruby | ``ruby -c`` syntax | clean |
| JavaScript | node syntax-clean (snake_case property names match SDK wire format) | clean |
| C# | full ``MSBuild`` restore + build against 4.1.88 | 0 errors |
| Java | edits applied; build deferred until Maven publishes 4.1.88 | n/a |

The TypeScript compile and PHP reflection passes flushed out a number of field-name assumptions that were wrong against the actual SDK shapes, and those corrections were applied uniformly across all 7 ports — most notably ``Currency``-wrapped money fields (need ``.localized``), ``shipping_handling_total`` not ``shipping_handling``, ``transaction_timestamp``/``transaction_gateway`` not ``dts``/``transaction_type``/``amount`` on ``OrderPaymentTransaction``, and the day/evening/cell phone fallback chain on ``OrderBilling``.

## Test plan

- [ ] Replace ``Constants.API_KEY`` (or equivalent) with a valid simple key for a merchant that has at least one order with email + page-view tracking
- [ ] Run the PHP sample against a regular (non-subscription) order and confirm Section 2 reports "NOT part of an auto order subscription"
- [ ] Run any sample against a subscription **rebill** order — confirm Section 4 surfaces the "subscription rebill" note and pulls page views from the original order id
- [ ] Cross-spot-check one other language port (Python or TypeScript recommended) to confirm output shape matches PHP
- [ ] Sanity-check that the C# sample builds in your local Visual Studio (build was validated via MSBuild from the command line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)