### PR TITLE
Add shipment tracking section to chargeback evidence samples

### DIFF
--- a/csharp/order/GetChargebackEvidence.cs
+++ b/csharp/order/GetChargebackEvidence.cs
@@ -32,6 +32,14 @@ namespace SdkSample.order
     ///      auto-order-level email log. For rebills specifically, the page-view
     ///      lookup pivots to the ORIGINAL order (the rebill itself has no
     ///      checkout session).
+    ///   5. Shipment journey data via the shipping.tracking_number_details
+    ///      expansion - carrier, current status, ETA, and per-scan event
+    ///      history. The standard "proof of delivery" exhibit for "item not
+    ///      received" chargebacks. NOTE: package tracking is an OPTIONAL feature
+    ///      that the merchant has to enable on their UltraCart account. If it
+    ///      is not enabled, or if tracking has not yet been posted for the
+    ///      order, the array will be empty and the section falls back to the
+    ///      plain TrackingNumbers list (if any).
     ///
     /// Requires the May 2026 SDK build with GetOrderEmails,
     /// GetOrderPageViewHistory, and GetAutoOrderEmails.
@@ -42,6 +50,7 @@ namespace SdkSample.order
         {
             "billing",                  // address customer entered for billing
             "shipping",                 // address goods shipped to
+            "shipping.tracking_number_details", // carrier scans, delivery status, ETA (requires the optional package-tracking feature)
             "payment",                  // payment method, card last four, gateway info
             "payment.transaction",      // auth/capture/refund timeline
             "summary",                  // totals, tax, shipping, weights
@@ -124,6 +133,7 @@ namespace SdkSample.order
 
             RenderHeader(orderId);
             RenderOrderOverview(order);
+            RenderShipmentTracking(order.Shipping);
             RenderSubscription(autoOrder, rebillOrders, orderId, autoOrderEmails);
             RenderEmails(emails);
             RenderPageViewHistory(pageViews, sessionReferrer, pageViewOrderId, pageViewIsRedirected);
@@ -241,9 +251,81 @@ namespace SdkSample.order
             }
         }
 
+        private static void RenderShipmentTracking(OrderShipping shipping)
+        {
+            Section("2. SHIPMENT TRACKING");
+
+            if (shipping == null)
+            {
+                Console.WriteLine("  No shipping address on file - this order may not have been a physical shipment.");
+                return;
+            }
+
+            List<OrderTrackingNumberDetails> trackingDetails = shipping.TrackingNumberDetails ?? new List<OrderTrackingNumberDetails>();
+            List<string> plainTrackings = shipping.TrackingNumbers ?? new List<string>();
+
+            if (trackingDetails.Count > 0)
+            {
+                // Rich tracking data - carrier, status, ETA, per-scan events.
+                for (int idx = 0; idx < trackingDetails.Count; idx++)
+                {
+                    OrderTrackingNumberDetails td = trackingDetails[idx];
+                    if (trackingDetails.Count > 1) Subsection($"Shipment {idx + 1} of {trackingDetails.Count}");
+
+                    Kv("Carrier",           td.ShippingMethod);
+                    Kv("Tracking #",        td.TrackingNumber);
+                    string statusText = ((td.Status ?? "") + "  " + (td.StatusDescription ?? "")).Trim();
+                    Kv("Status",            statusText.Length == 0 ? null : statusText);
+                    Kv("Tracking URL",      td.TrackingUrl);
+                    Kv("Shipped",           td.ShippedDateFormatted ?? td.ShippedDate);
+                    Kv("Expected Delivery", td.ExpectedDeliveryDateFormatted ?? td.ExpectedDeliveryDate);
+                    Kv("Actual Delivery",   td.ActualDeliveryDateFormatted   ?? td.ActualDeliveryDate);
+
+                    List<OrderTrackingNumberDetail> events = td.Details ?? new List<OrderTrackingNumberDetail>();
+                    if (events.Count == 0)
+                    {
+                        Console.WriteLine();
+                        Console.WriteLine("  No tracking events captured yet.");
+                    }
+                    else
+                    {
+                        Subsection("Tracking Events");
+                        // Most carriers feed events newest-first; preserve whatever order the API returned.
+                        foreach (OrderTrackingNumberDetail ev in events)
+                        {
+                            string when = ev.EventDts ?? ((ev.EventLocalDate ?? "") + " " + (ev.EventLocalTime ?? "")).Trim();
+                            string tag = ev.TagDescription ?? ev.Tag ?? "";
+                            string location = JoinNonEmpty(", ", ev.City, ev.State);
+                            Console.WriteLine($"  {Pad(when, 22)} {Pad(Shorten(tag, 22), 22)} {location}");
+                            if (!string.IsNullOrEmpty(ev.SubtagMessage))
+                                Console.WriteLine($"  {new string(' ', 22)} {ev.SubtagMessage}");
+                        }
+                    }
+                }
+            }
+            else if (plainTrackings.Count > 0)
+            {
+                // Feature not enabled (or carrier feed unavailable) - fall back to
+                // the plain tracking numbers we have on file.
+                Console.WriteLine("  Detailed carrier scan data is not available for this order.");
+                Console.WriteLine("  (Detailed tracking is an optional UltraCart feature that must be enabled");
+                Console.WriteLine("  on the merchant account. Falling back to the plain tracking numbers below.)");
+                Subsection("Tracking Numbers");
+                foreach (string tn in plainTrackings) Console.WriteLine("  " + tn);
+            }
+            else
+            {
+                Console.WriteLine("  No shipment tracking on file for this order.");
+                Console.WriteLine("  This is expected for digital goods, will-call/pickup orders, or orders");
+                Console.WriteLine("  where tracking has not yet been posted by the carrier. Detailed carrier");
+                Console.WriteLine("  scan data also requires the optional package-tracking feature to be");
+                Console.WriteLine("  enabled on the merchant account.");
+            }
+        }
+
         private static void RenderSubscription(AutoOrder autoOrder, List<Order> rebillOrders, string currentOrderId, List<AutoOrderEmail> autoOrderEmails)
         {
-            Section("2. SUBSCRIPTION DETAILS");
+            Section("3. SUBSCRIPTION DETAILS");
 
             if (autoOrder == null)
             {
@@ -311,7 +393,7 @@ namespace SdkSample.order
 
         private static void RenderEmails(List<OrderEmail> emails)
         {
-            Section($"3. EMAIL DELIVERY ({emails.Count} messages)");
+            Section($"4. EMAIL DELIVERY ({emails.Count} messages)");
             if (emails.Count == 0)
             {
                 Console.WriteLine("  No email delivery records on file for this order.");
@@ -376,7 +458,7 @@ namespace SdkSample.order
 
         private static void RenderPageViewHistory(List<OrderPageView> pageViews, string sessionReferrer, string sourceOrderId, bool isRedirected)
         {
-            Section($"4. PAGE VIEW HISTORY ({pageViews.Count} views)");
+            Section($"5. PAGE VIEW HISTORY ({pageViews.Count} views)");
             if (isRedirected)
             {
                 Console.WriteLine("  Note: this is a subscription rebill. The disputed order itself has no");

--- a/java/src/order/GetChargebackEvidence.java
+++ b/java/src/order/GetChargebackEvidence.java
@@ -32,6 +32,14 @@ import java.util.*;
  *      the parent subscription, every rebill, and the auto-order-level email
  *      log. For rebills specifically, the page-view lookup pivots to the
  *      ORIGINAL order (the rebill itself has no checkout session).
+ *   5. Shipment journey data via the shipping.tracking_number_details
+ *      expansion - carrier, current status, ETA, and per-scan event history.
+ *      The standard "proof of delivery" exhibit for "item not received"
+ *      chargebacks. NOTE: package tracking is an OPTIONAL feature that the
+ *      merchant has to enable on their UltraCart account. If it is not
+ *      enabled, or if tracking has not yet been posted for the order, the
+ *      array will be empty and the section falls back to the plain
+ *      trackingNumbers list (if any).
  *
  * Requires the May 2026 SDK build with getOrderEmails,
  * getOrderPageViewHistory, and getAutoOrderEmails.
@@ -41,6 +49,7 @@ public class GetChargebackEvidence {
     private static final String ORDER_EXPANSION = String.join(",",
         "billing",                  // address customer entered for billing
         "shipping",                 // address goods shipped to
+        "shipping.tracking_number_details", // carrier scans, delivery status, ETA (requires the optional package-tracking feature)
         "payment",                  // payment method, card last four, gateway info
         "payment.transaction",      // auth/capture/refund timeline
         "summary",                  // totals, tax, shipping, weights
@@ -118,6 +127,7 @@ public class GetChargebackEvidence {
 
         renderHeader(orderId);
         renderOrderOverview(order);
+        renderShipmentTracking(order.getShipping());
         renderSubscription(autoOrder, rebillOrders, orderId, autoOrderEmails);
         renderEmails(emails);
         renderPageViewHistory(pageViews, sessionReferrer, pageViewOrderId, pageViewIsRedirected);
@@ -244,8 +254,74 @@ public class GetChargebackEvidence {
         }
     }
 
+    private void renderShipmentTracking(OrderShipping shipping) {
+        section("2. SHIPMENT TRACKING");
+
+        if (shipping == null) {
+            System.out.println("  No shipping address on file - this order may not have been a physical shipment.");
+            return;
+        }
+
+        List<OrderTrackingNumberDetails> trackingDetails = shipping.getTrackingNumberDetails() != null
+                ? shipping.getTrackingNumberDetails() : Collections.emptyList();
+        List<String> plainTrackings = shipping.getTrackingNumbers() != null
+                ? shipping.getTrackingNumbers() : Collections.emptyList();
+
+        if (!trackingDetails.isEmpty()) {
+            // Rich tracking data - carrier, status, ETA, per-scan events.
+            for (int idx = 0; idx < trackingDetails.size(); idx++) {
+                OrderTrackingNumberDetails td = trackingDetails.get(idx);
+                if (trackingDetails.size() > 1) subsection("Shipment " + (idx + 1) + " of " + trackingDetails.size());
+
+                kv("Carrier",           td.getShippingMethod());
+                kv("Tracking #",        td.getTrackingNumber());
+                String statusText = (safeStr(td.getStatus()) + "  " + safeStr(td.getStatusDescription())).trim();
+                kv("Status",            statusText.isEmpty() ? null : statusText);
+                kv("Tracking URL",      td.getTrackingUrl());
+                kv("Shipped",           td.getShippedDateFormatted() != null ? td.getShippedDateFormatted() : td.getShippedDate());
+                kv("Expected Delivery", td.getExpectedDeliveryDateFormatted() != null ? td.getExpectedDeliveryDateFormatted() : td.getExpectedDeliveryDate());
+                kv("Actual Delivery",   td.getActualDeliveryDateFormatted()   != null ? td.getActualDeliveryDateFormatted()   : td.getActualDeliveryDate());
+
+                List<OrderTrackingNumberDetail> events = td.getDetails() != null ? td.getDetails() : Collections.emptyList();
+                if (events.isEmpty()) {
+                    System.out.println();
+                    System.out.println("  No tracking events captured yet.");
+                } else {
+                    subsection("Tracking Events");
+                    // Most carriers feed events newest-first; preserve whatever order the API returned.
+                    for (OrderTrackingNumberDetail ev : events) {
+                        String when = ev.getEventDts() != null
+                                ? ev.getEventDts()
+                                : (safeStr(ev.getEventLocalDate()) + " " + safeStr(ev.getEventLocalTime())).trim();
+                        String tag = ev.getTagDescription() != null ? ev.getTagDescription()
+                                : (ev.getTag() != null ? ev.getTag() : "");
+                        String location = joinNonEmpty(", ", ev.getCity(), ev.getState());
+                        System.out.printf("  %-22s %-22s %s%n", safeStr(when), shorten(tag, 22), location);
+                        if (ev.getSubtagMessage() != null && !ev.getSubtagMessage().isEmpty()) {
+                            System.out.printf("  %22s %s%n", "", ev.getSubtagMessage());
+                        }
+                    }
+                }
+            }
+        } else if (!plainTrackings.isEmpty()) {
+            // Feature not enabled (or carrier feed unavailable) - fall back to
+            // the plain tracking numbers we have on file.
+            System.out.println("  Detailed carrier scan data is not available for this order.");
+            System.out.println("  (Detailed tracking is an optional UltraCart feature that must be enabled");
+            System.out.println("  on the merchant account. Falling back to the plain tracking numbers below.)");
+            subsection("Tracking Numbers");
+            for (String tn : plainTrackings) System.out.println("  " + tn);
+        } else {
+            System.out.println("  No shipment tracking on file for this order.");
+            System.out.println("  This is expected for digital goods, will-call/pickup orders, or orders");
+            System.out.println("  where tracking has not yet been posted by the carrier. Detailed carrier");
+            System.out.println("  scan data also requires the optional package-tracking feature to be");
+            System.out.println("  enabled on the merchant account.");
+        }
+    }
+
     private void renderSubscription(AutoOrder autoOrder, List<Order> rebillOrders, String currentOrderId, List<AutoOrderEmail> autoOrderEmails) {
-        section("2. SUBSCRIPTION DETAILS");
+        section("3. SUBSCRIPTION DETAILS");
         if (autoOrder == null) {
             System.out.println("  This order is NOT part of an auto order subscription.");
             return;
@@ -308,7 +384,7 @@ public class GetChargebackEvidence {
     }
 
     private void renderEmails(List<OrderEmail> emails) {
-        section("3. EMAIL DELIVERY (" + emails.size() + " messages)");
+        section("4. EMAIL DELIVERY (" + emails.size() + " messages)");
         if (emails.isEmpty()) {
             System.out.println("  No email delivery records on file for this order.");
             return;
@@ -371,7 +447,7 @@ public class GetChargebackEvidence {
     }
 
     private void renderPageViewHistory(List<OrderPageView> pageViews, String sessionReferrer, String sourceOrderId, boolean isRedirected) {
-        section("4. PAGE VIEW HISTORY (" + pageViews.size() + " views)");
+        section("5. PAGE VIEW HISTORY (" + pageViews.size() + " views)");
         if (isRedirected) {
             System.out.println("  Note: this is a subscription rebill. The disputed order itself has no");
             System.out.println("  checkout session of its own. The page views below are from the ORIGINAL");

--- a/javascript/order/getChargebackEvidence.js
+++ b/javascript/order/getChargebackEvidence.js
@@ -22,6 +22,14 @@ import { orderApi, autoOrderApi } from '../api.js';
  *      the parent subscription, every rebill, and the auto-order-level email
  *      log. For rebills specifically, the page-view lookup pivots to the
  *      ORIGINAL order (the rebill itself has no checkout session).
+ *   5. Shipment journey data via the shipping.tracking_number_details
+ *      expansion - carrier, current status, ETA, and per-scan event history.
+ *      The standard "proof of delivery" exhibit for "item not received"
+ *      chargebacks. NOTE: package tracking is an OPTIONAL feature that the
+ *      merchant has to enable on their UltraCart account. If it is not
+ *      enabled, or if tracking has not yet been posted for the order, the
+ *      array will be empty and the section falls back to the plain
+ *      tracking_numbers list (if any).
  *
  * Run:
  *   NODE_TLS_REJECT_UNAUTHORIZED=0 node order/getChargebackEvidence.js DEMO-0009104976
@@ -33,7 +41,11 @@ export async function execute() {
     const orderId = process.argv[2] || 'DEMO-0009104976';
 
     const orderExpansion = [
-        'billing', 'shipping', 'payment', 'payment.transaction', 'summary',
+        'billing', 'shipping',
+        // shipping.tracking_number_details - carrier scans, delivery status, ETA
+        // (requires the optional package-tracking feature)
+        'shipping.tracking_number_details',
+        'payment', 'payment.transaction', 'summary',
         'items', 'coupon', 'customer_profile', 'auto_order', 'utms',
         'marketing', 'gift', 'point_of_sale', 'channel_partner',
     ].join(',');
@@ -91,6 +103,7 @@ export async function execute() {
 
         renderHeader(orderId);
         renderOrderOverview(order);
+        renderShipmentTracking(order.shipping);
         renderSubscription(autoOrder, rebillOrders, orderId, autoOrderEmails);
         renderEmails(emails);
         renderPageViewHistory(pageViews, sessionReferrer, pageViewOrderId, pageViewIsRedirected);
@@ -197,8 +210,66 @@ function renderOrderOverview(order) {
     }
 }
 
+function renderShipmentTracking(shipping) {
+    section('2. SHIPMENT TRACKING');
+
+    if (!shipping) {
+        console.log('  No shipping address on file - this order may not have been a physical shipment.');
+        return;
+    }
+
+    const trackingDetails = shipping.tracking_number_details || [];
+    const plainTrackings = shipping.tracking_numbers || [];
+
+    if (trackingDetails.length > 0) {
+        // Rich tracking data - carrier, status, ETA, per-scan events.
+        trackingDetails.forEach((td, idx) => {
+            if (trackingDetails.length > 1) subsection(`Shipment ${idx + 1} of ${trackingDetails.length}`);
+
+            kv('Carrier',           td.shipping_method);
+            kv('Tracking #',        td.tracking_number);
+            const statusText = `${td.status || ''}  ${td.status_description || ''}`.trim();
+            kv('Status',            statusText || null);
+            kv('Tracking URL',      td.tracking_url);
+            kv('Shipped',           td.shipped_date_formatted           || td.shipped_date);
+            kv('Expected Delivery', td.expected_delivery_date_formatted || td.expected_delivery_date);
+            kv('Actual Delivery',   td.actual_delivery_date_formatted   || td.actual_delivery_date);
+
+            const events = td.details || [];
+            if (events.length === 0) {
+                console.log();
+                console.log('  No tracking events captured yet.');
+            } else {
+                subsection('Tracking Events');
+                // Most carriers feed events newest-first; preserve whatever order the API returned.
+                for (const ev of events) {
+                    const when = ev.event_dts || `${ev.event_local_date || ''} ${ev.event_local_time || ''}`.trim();
+                    const tag = ev.tag_description || ev.tag || '';
+                    const location = [ev.city, ev.state].filter(Boolean).join(', ');
+                    console.log(`  ${pad(when || '', 22)} ${pad(shorten(tag, 22), 22)} ${location}`);
+                    if (ev.subtag_message) console.log(`  ${' '.repeat(22)} ${ev.subtag_message}`);
+                }
+            }
+        });
+    } else if (plainTrackings.length > 0) {
+        // Feature not enabled (or carrier feed unavailable) - fall back to the
+        // plain tracking numbers we have on file.
+        console.log('  Detailed carrier scan data is not available for this order.');
+        console.log('  (Detailed tracking is an optional UltraCart feature that must be enabled');
+        console.log('  on the merchant account. Falling back to the plain tracking numbers below.)');
+        subsection('Tracking Numbers');
+        for (const tn of plainTrackings) console.log(`  ${tn}`);
+    } else {
+        console.log('  No shipment tracking on file for this order.');
+        console.log('  This is expected for digital goods, will-call/pickup orders, or orders');
+        console.log('  where tracking has not yet been posted by the carrier. Detailed carrier');
+        console.log('  scan data also requires the optional package-tracking feature to be');
+        console.log('  enabled on the merchant account.');
+    }
+}
+
 function renderSubscription(autoOrder, rebillOrders, currentOrderId, autoOrderEmails) {
-    section('2. SUBSCRIPTION DETAILS');
+    section('3. SUBSCRIPTION DETAILS');
 
     if (!autoOrder) {
         console.log('  This order is NOT part of an auto order subscription.');
@@ -257,7 +328,7 @@ function renderSubscription(autoOrder, rebillOrders, currentOrderId, autoOrderEm
 }
 
 function renderEmails(emails) {
-    section(`3. EMAIL DELIVERY (${emails.length} messages)`);
+    section(`4. EMAIL DELIVERY (${emails.length} messages)`);
     if (emails.length === 0) {
         console.log('  No email delivery records on file for this order.');
         return;
@@ -289,7 +360,7 @@ function renderEmailDetail(i, email) {
 }
 
 function renderPageViewHistory(pageViews, sessionReferrer, sourceOrderId, isRedirected) {
-    section(`4. PAGE VIEW HISTORY (${pageViews.length} views)`);
+    section(`5. PAGE VIEW HISTORY (${pageViews.length} views)`);
     if (isRedirected) {
         console.log("  Note: this is a subscription rebill. The disputed order itself has no");
         console.log("  checkout session of its own. The page views below are from the ORIGINAL");

--- a/php/order/getChargebackEvidence.php
+++ b/php/order/getChargebackEvidence.php
@@ -11,8 +11,9 @@
  *      Notice we list every expansion explicitly - no shortcuts. Listing them
  *      individually keeps your payload small and forces you to think about
  *      what evidence each one represents.
- *   2. Email delivery records (the customer was notified, when, by which path,
- *      whether they opened/bounced/clicked).
+ *   2. Email delivery records via the dedicated /emails endpoint (not via
+ *      expansion). Use the dedicated endpoint for chargeback work - it is the
+ *      canonical full-fidelity source for SES delivery events on every order.
  *   3. Page view history (the customer was on your site, navigated through
  *      pages, spent time before placing the order).
  *   4. Auto-order detection: a large fraction of chargebacks are subscription
@@ -20,6 +21,14 @@
  *      an auto order, this sample pulls the parent subscription, every rebill
  *      that has occurred on it, and the auto-order-level email log so you can
  *      show the rebill schedule was disclosed and notified.
+ *   5. Shipment journey data via the shipping.tracking_number_details
+ *      expansion - carrier, current status, ETA, and per-scan event history.
+ *      The standard "proof of delivery" exhibit for "item not received"
+ *      chargebacks. NOTE: package tracking is an OPTIONAL feature that the
+ *      merchant has to enable on their UltraCart account. If it is not
+ *      enabled, or if tracking has not yet been posted for the order, the
+ *      array will be empty and the section falls back to the plain
+ *      tracking_numbers list (if any).
  *
  * Usage:
  *   php order/getChargebackEvidence.php DEMO-0009104976
@@ -59,6 +68,7 @@ $auto_order_api = AutoOrderApi::usingApiKey(Constants::API_KEY, false, false);
 $order_expansion = implode(',', [
     'billing',                 // address customer entered for billing
     'shipping',                // address goods shipped to
+    'shipping.tracking_number_details', // carrier scans, delivery status, ETA (requires the optional package-tracking feature)
     'payment',                 // payment method, card last four, gateway info
     'payment.transaction',     // auth/capture/refund timeline
     'summary',                 // totals, tax, shipping, weights
@@ -148,6 +158,7 @@ if (!$is_cli) echo '<html lang="en"><body><pre>';
 
 renderHeader($order_id);
 renderOrderOverview($order);
+renderShipmentTracking($order->getShipping());
 renderSubscription($auto_order, $rebill_orders, $order_id, $auto_order_emails);
 renderEmails($emails);
 renderPageViewHistory($page_views, $session_referrer, $page_view_order_id, $page_view_is_redirected);
@@ -292,8 +303,77 @@ function renderOrderOverview($order): void {
     echo "\n";
 }
 
+function renderShipmentTracking($shipping): void {
+    section('2. SHIPMENT TRACKING');
+
+    if ($shipping === null) {
+        echo "  No shipping address on file - this order may not have been a physical shipment.\n\n";
+        return;
+    }
+
+    $tracking_details = method_exists($shipping, 'getTrackingNumberDetails')
+        ? ($shipping->getTrackingNumberDetails() ?? [])
+        : [];
+    $plain_trackings = method_exists($shipping, 'getTrackingNumbers')
+        ? ($shipping->getTrackingNumbers() ?? [])
+        : [];
+
+    if (!empty($tracking_details)) {
+        // Rich tracking data - carrier, status, ETA, per-scan events.
+        foreach ($tracking_details as $idx => $td) {
+            if (count($tracking_details) > 1) {
+                subsection('Shipment ' . ($idx + 1) . ' of ' . count($tracking_details));
+            }
+            kv('Carrier',           $td->getShippingMethod());
+            kv('Tracking #',        $td->getTrackingNumber());
+            $status_text = trim(($td->getStatus() ?? '') . '  ' . ($td->getStatusDescription() ?? ''));
+            kv('Status',            $status_text === '' ? null : $status_text);
+            kv('Tracking URL',      $td->getTrackingUrl());
+            kv('Shipped',           $td->getShippedDateFormatted()           ?? $td->getShippedDate());
+            kv('Expected Delivery', $td->getExpectedDeliveryDateFormatted() ?? $td->getExpectedDeliveryDate());
+            kv('Actual Delivery',   $td->getActualDeliveryDateFormatted()   ?? $td->getActualDeliveryDate());
+
+            $events = $td->getDetails() ?? [];
+            if (empty($events)) {
+                echo "\n  No tracking events captured yet.\n";
+            } else {
+                subsection('Tracking Events');
+                // Most carriers feed events newest-first; preserve whatever order the API returned.
+                foreach ($events as $ev) {
+                    $when = $ev->getEventDts()
+                        ?? trim(($ev->getEventLocalDate() ?? '') . ' ' . ($ev->getEventLocalTime() ?? ''));
+                    $tag = $ev->getTagDescription() ?? $ev->getTag() ?? '';
+                    $location = implode(', ', array_filter([$ev->getCity(), $ev->getState()]));
+                    echo sprintf("  %-22s %-22s %s\n", $when ?? '', shorten($tag, 22), $location);
+                    $sub = $ev->getSubtagMessage() ?? '';
+                    if ($sub !== '') {
+                        echo str_repeat(' ', 25) . $sub . "\n";
+                    }
+                }
+            }
+        }
+    } elseif (!empty($plain_trackings)) {
+        // Feature not enabled (or carrier feed unavailable) - fall back to the
+        // plain tracking numbers we have on file.
+        echo "  Detailed carrier scan data is not available for this order.\n";
+        echo "  (Detailed tracking is an optional UltraCart feature that must be enabled\n";
+        echo "  on the merchant account. Falling back to the plain tracking numbers below.)\n";
+        subsection('Tracking Numbers');
+        foreach ($plain_trackings as $tn) {
+            echo "  $tn\n";
+        }
+    } else {
+        echo "  No shipment tracking on file for this order.\n";
+        echo "  This is expected for digital goods, will-call/pickup orders, or orders\n";
+        echo "  where tracking has not yet been posted by the carrier. Detailed carrier\n";
+        echo "  scan data also requires the optional package-tracking feature to be\n";
+        echo "  enabled on the merchant account.\n";
+    }
+    echo "\n";
+}
+
 function renderSubscription($auto_order, array $rebill_orders, string $current_order_id, array $auto_order_emails): void {
-    section('2. SUBSCRIPTION DETAILS');
+    section('3. SUBSCRIPTION DETAILS');
 
     if ($auto_order === null) {
         echo "  This order is NOT part of an auto order subscription.\n";
@@ -369,7 +449,7 @@ function renderSubscription($auto_order, array $rebill_orders, string $current_o
 }
 
 function renderEmails(array $emails): void {
-    section('3. EMAIL DELIVERY (' . count($emails) . ' messages)');
+    section('4. EMAIL DELIVERY (' . count($emails) . ' messages)');
 
     if (empty($emails)) {
         echo "  No email delivery records on file for this order.\n";
@@ -401,8 +481,8 @@ function renderEmailDetail(int $i, $email): void {
 
     if ($email->getDeliveryDts() !== null)
         echo sprintf("      Delivered:        %s\n", $email->getDeliveryDts());
-    if ($email->getReportingMTA() !== null)
-        echo sprintf("      Reporting MTA:    %s\n", $email->getReportingMTA());
+    if ($email->getReportingMta() !== null)
+        echo sprintf("      Reporting MTA:    %s\n", $email->getReportingMta());
     if ($email->getSmtpResponse() !== null)
         echo sprintf("      SMTP response:    %s\n", $email->getSmtpResponse());
     if ($email->getBounceType() !== null)
@@ -415,7 +495,7 @@ function renderEmailDetail(int $i, $email): void {
 }
 
 function renderPageViewHistory(array $page_views, ?string $session_referrer, string $source_order_id, bool $is_redirected): void {
-    section('4. PAGE VIEW HISTORY (' . count($page_views) . ' views)');
+    section('5. PAGE VIEW HISTORY (' . count($page_views) . ' views)');
 
     if ($is_redirected) {
         echo "  Note: this is a subscription rebill. The disputed order itself has no\n";

--- a/python/order/get_chargeback_evidence.py
+++ b/python/order/get_chargeback_evidence.py
@@ -21,6 +21,13 @@ What this sample demonstrates:
      that has occurred on it, and the auto-order-level email log. For rebills
      specifically, the page-view lookup pivots to the ORIGINAL order, since
      the rebill itself has no checkout session.
+  5. Shipment journey data via the shipping.tracking_number_details expansion
+     - carrier, current status, ETA, and per-scan event history. This is the
+     standard "proof of delivery" exhibit for "item not received" chargebacks.
+     NOTE: package tracking is an OPTIONAL feature that the merchant has to
+     enable on their UltraCart account. If it is not enabled, or if tracking
+     has not yet been posted for the order, the array will be empty and the
+     section will say so.
 
 Usage:
     PYTHONPATH=. python order/get_chargeback_evidence.py DEMO-0009104976
@@ -51,6 +58,7 @@ auto_order_api = AutoOrderApi(client)
 order_expansion = ",".join([
     "billing",                  # address customer entered for billing
     "shipping",                 # address goods shipped to
+    "shipping.tracking_number_details",  # carrier scans, delivery status, ETA (requires the optional package-tracking feature)
     "payment",                  # payment method, card last four, gateway info
     "payment.transaction",      # auth/capture/refund timeline
     "summary",                  # totals, tax, shipping, weights
@@ -310,8 +318,68 @@ else:
     kv("Most recent UTM campaign", most_recent.utm_campaign)
     kv("UTM clicks captured", str(len(utms)))
 
-# Section 2: Subscription
-section("2. SUBSCRIPTION DETAILS")
+# Section 2: Shipment tracking
+section("2. SHIPMENT TRACKING")
+shipping = order.shipping
+if shipping is None:
+    print("  No shipping address on file - this order may not have been a physical shipment.")
+else:
+    tracking_details = getattr(shipping, "tracking_number_details", None) or []
+    plain_trackings = getattr(shipping, "tracking_numbers", None) or []
+
+    if tracking_details:
+        # Rich tracking data - carrier, status, ETA, per-scan events.
+        for idx, td in enumerate(tracking_details, start=1):
+            if len(tracking_details) > 1:
+                subsection(f"Shipment {idx} of {len(tracking_details)}")
+            kv("Carrier",           getattr(td, "shipping_method", None))
+            kv("Tracking #",        getattr(td, "tracking_number", None))
+            status = getattr(td, "status", None) or ""
+            desc = getattr(td, "status_description", None) or ""
+            kv("Status",            f"{status}  {desc}".strip() or None)
+            kv("Tracking URL",      getattr(td, "tracking_url", None))
+            kv("Shipped",           getattr(td, "shipped_date_formatted", None) or getattr(td, "shipped_date", None))
+            kv("Expected Delivery", getattr(td, "expected_delivery_date_formatted", None) or getattr(td, "expected_delivery_date", None))
+            kv("Actual Delivery",   getattr(td, "actual_delivery_date_formatted", None) or getattr(td, "actual_delivery_date", None))
+
+            events = getattr(td, "details", None) or []
+            if not events:
+                print()
+                print("  No tracking events captured yet.")
+            else:
+                subsection("Tracking Events")
+                # Most carriers feed events newest-first; preserve whatever order the API returned.
+                for ev in events:
+                    when = getattr(ev, "event_dts", None) or (
+                        f"{getattr(ev, 'event_local_date', '') or ''} {getattr(ev, 'event_local_time', '') or ''}".strip()
+                    )
+                    tag = getattr(ev, "tag_description", None) or getattr(ev, "tag", None) or ""
+                    city = getattr(ev, "city", None) or ""
+                    state = getattr(ev, "state", None) or ""
+                    location = ", ".join(filter(None, [city, state]))
+                    sub = getattr(ev, "subtag_message", None) or ""
+                    print(f"  {(when or '').ljust(22)} {shorten(tag, 22).ljust(22)} {location}")
+                    if sub:
+                        print(f"  {' ' * 22} {sub}")
+    elif plain_trackings:
+        # Feature not enabled (or carrier feed unavailable) - fall back to the
+        # plain tracking numbers we have on file.
+        print("  Detailed carrier scan data is not available for this order.")
+        print("  (Detailed tracking is an optional UltraCart feature that must be enabled")
+        print("  on the merchant account. Falling back to the plain tracking numbers below.)")
+        print()
+        subsection("Tracking Numbers")
+        for tn in plain_trackings:
+            print(f"  {tn}")
+    else:
+        print("  No shipment tracking on file for this order.")
+        print("  This is expected for digital goods, will-call/pickup orders, or orders")
+        print("  where tracking has not yet been posted by the carrier. Detailed carrier")
+        print("  scan data also requires the optional package-tracking feature to be")
+        print("  enabled on the merchant account.")
+
+# Section 3: Subscription
+section("3. SUBSCRIPTION DETAILS")
 if auto_order is None:
     print("  This order is NOT part of an auto order subscription.")
 else:
@@ -351,16 +419,16 @@ else:
         subsection("Subscription-Level Emails")
         print("  No subscription-level emails on record.")
 
-# Section 3: Emails
-section(f"3. EMAIL DELIVERY ({len(emails)} messages)")
+# Section 4: Emails
+section(f"4. EMAIL DELIVERY ({len(emails)} messages)")
 if not emails:
     print("  No email delivery records on file for this order.")
 else:
     for i, email in enumerate(emails, start=1):
         render_email_detail(i, email)
 
-# Section 4: Page view history
-section(f"4. PAGE VIEW HISTORY ({len(page_views)} views)")
+# Section 5: Page view history
+section(f"5. PAGE VIEW HISTORY ({len(page_views)} views)")
 if page_view_is_redirected:
     print("  Note: this is a subscription rebill. The disputed order itself has no")
     print("  checkout session of its own. The page views below are from the ORIGINAL")

--- a/ruby/order/get_chargeback_evidence.rb
+++ b/ruby/order/get_chargeback_evidence.rb
@@ -20,6 +20,13 @@
 #      that has occurred on it, and the auto-order-level email log. For rebills
 #      specifically, the page-view lookup pivots to the ORIGINAL order, since
 #      the rebill itself has no checkout session.
+#   5. Shipment journey data via the shipping.tracking_number_details expansion
+#      - carrier, current status, ETA, and per-scan event history. This is the
+#      standard "proof of delivery" exhibit for "item not received" chargebacks.
+#      NOTE: package tracking is an OPTIONAL feature that the merchant has to
+#      enable on their UltraCart account. If it is not enabled, or if tracking
+#      has not yet been posted for the order, the array will be empty and the
+#      section will fall back to the plain tracking_numbers list (if any).
 #
 # Usage:
 #   ruby order/get_chargeback_evidence.rb DEMO-0009104976
@@ -42,6 +49,7 @@ auto_order_api = UltracartClient::AutoOrderApi.new_using_api_key(Constants::API_
 order_expansion = %w[
   billing
   shipping
+  shipping.tracking_number_details
   payment
   payment.transaction
   summary
@@ -303,8 +311,68 @@ else
   kv('UTM clicks captured', utms.length.to_s)
 end
 
-# Section 2: Subscription
-section('2. SUBSCRIPTION DETAILS')
+# Section 2: Shipment tracking
+section('2. SHIPMENT TRACKING')
+shipping = order.shipping
+if shipping.nil?
+  puts '  No shipping address on file - this order may not have been a physical shipment.'
+else
+  tracking_details = shipping.respond_to?(:tracking_number_details) ? (shipping.tracking_number_details || []) : []
+  plain_trackings  = shipping.respond_to?(:tracking_numbers)        ? (shipping.tracking_numbers || [])        : []
+
+  if !tracking_details.empty?
+    # Rich tracking data - carrier, status, ETA, per-scan events.
+    tracking_details.each_with_index do |td, idx|
+      subsection("Shipment #{idx + 1} of #{tracking_details.length}") if tracking_details.length > 1
+      kv('Carrier',           td.respond_to?(:shipping_method) ? td.shipping_method : nil)
+      kv('Tracking #',        td.respond_to?(:tracking_number) ? td.tracking_number : nil)
+      status_text = "#{td.respond_to?(:status) ? td.status : ''}  #{td.respond_to?(:status_description) ? td.status_description : ''}".strip
+      kv('Status',            status_text.empty? ? nil : status_text)
+      kv('Tracking URL',      td.respond_to?(:tracking_url) ? td.tracking_url : nil)
+      kv('Shipped',           (td.respond_to?(:shipped_date_formatted) && td.shipped_date_formatted) || (td.respond_to?(:shipped_date) ? td.shipped_date : nil))
+      kv('Expected Delivery', (td.respond_to?(:expected_delivery_date_formatted) && td.expected_delivery_date_formatted) || (td.respond_to?(:expected_delivery_date) ? td.expected_delivery_date : nil))
+      kv('Actual Delivery',   (td.respond_to?(:actual_delivery_date_formatted) && td.actual_delivery_date_formatted) || (td.respond_to?(:actual_delivery_date) ? td.actual_delivery_date : nil))
+
+      events = td.respond_to?(:details) ? (td.details || []) : []
+      if events.empty?
+        puts
+        puts '  No tracking events captured yet.'
+      else
+        subsection('Tracking Events')
+        # Most carriers feed events newest-first; preserve whatever order the API returned.
+        events.each do |ev|
+          when_s = (ev.respond_to?(:event_dts) && ev.event_dts) ||
+                   "#{ev.respond_to?(:event_local_date) ? ev.event_local_date : ''} #{ev.respond_to?(:event_local_time) ? ev.event_local_time : ''}".strip
+          tag = (ev.respond_to?(:tag_description) && ev.tag_description) || (ev.respond_to?(:tag) ? ev.tag : '') || ''
+          city = ev.respond_to?(:city) ? (ev.city || '') : ''
+          state = ev.respond_to?(:state) ? (ev.state || '') : ''
+          location = [city, state].reject { |s| s.nil? || s.empty? }.join(', ')
+          sub = ev.respond_to?(:subtag_message) ? (ev.subtag_message || '') : ''
+          printf("  %-22s %-22s %s\n", when_s || '', shorten(tag, 22), location)
+          puts "  #{' ' * 22} #{sub}" unless sub.empty?
+        end
+      end
+    end
+  elsif !plain_trackings.empty?
+    # Feature not enabled (or carrier feed unavailable) - fall back to the
+    # plain tracking numbers we have on file.
+    puts '  Detailed carrier scan data is not available for this order.'
+    puts '  (Detailed tracking is an optional UltraCart feature that must be enabled'
+    puts '  on the merchant account. Falling back to the plain tracking numbers below.)'
+    puts
+    subsection('Tracking Numbers')
+    plain_trackings.each { |tn| puts "  #{tn}" }
+  else
+    puts '  No shipment tracking on file for this order.'
+    puts '  This is expected for digital goods, will-call/pickup orders, or orders'
+    puts '  where tracking has not yet been posted by the carrier. Detailed carrier'
+    puts '  scan data also requires the optional package-tracking feature to be'
+    puts '  enabled on the merchant account.'
+  end
+end
+
+# Section 3: Subscription
+section('3. SUBSCRIPTION DETAILS')
 if auto_order.nil?
   puts '  This order is NOT part of an auto order subscription.'
 else
@@ -362,16 +430,16 @@ else
   end
 end
 
-# Section 3: Emails
-section("3. EMAIL DELIVERY (#{emails.length} messages)")
+# Section 4: Emails
+section("4. EMAIL DELIVERY (#{emails.length} messages)")
 if emails.empty?
   puts '  No email delivery records on file for this order.'
 else
   emails.each_with_index { |email, i| render_email_detail(i + 1, email) }
 end
 
-# Section 4: Page view history
-section("4. PAGE VIEW HISTORY (#{page_views.length} views)")
+# Section 5: Page view history
+section("5. PAGE VIEW HISTORY (#{page_views.length} views)")
 if page_view_is_redirected
   puts '  Note: this is a subscription rebill. The disputed order itself has no'
   puts '  checkout session of its own. The page views below are from the ORIGINAL'

--- a/typescript/order/GetChargebackEvidence.ts
+++ b/typescript/order/GetChargebackEvidence.ts
@@ -34,6 +34,14 @@ import {
  *      the parent subscription, every rebill, and the auto-order-level email
  *      log. For rebills specifically, the page-view lookup pivots to the
  *      ORIGINAL order (the rebill itself has no checkout session).
+ *   5. Shipment journey data via the shipping.tracking_number_details
+ *      expansion - carrier, current status, ETA, and per-scan event history.
+ *      The standard "proof of delivery" exhibit for "item not received"
+ *      chargebacks. NOTE: package tracking is an OPTIONAL feature that the
+ *      merchant has to enable on their UltraCart account. If it is not
+ *      enabled, or if tracking has not yet been posted for the order, the
+ *      array will be empty and the section falls back to the plain
+ *      tracking_numbers list (if any).
  *
  * Run:
  *   NODE_TLS_REJECT_UNAUTHORIZED=0 node order/GetChargebackEvidence.js DEMO-0009104976
@@ -50,6 +58,9 @@ export class GetChargebackEvidence {
         const orderExpansion = [
             'billing',
             'shipping',
+            // shipping.tracking_number_details - carrier scans, delivery status,
+            // ETA (requires the optional package-tracking feature).
+            'shipping.tracking_number_details',
             'payment',
             'payment.transaction',
             'summary',
@@ -119,6 +130,7 @@ export class GetChargebackEvidence {
 
             renderHeader(orderId);
             renderOrderOverview(order);
+            renderShipmentTracking(order.shipping);
             renderSubscription(autoOrder, rebillOrders, orderId, autoOrderEmails);
             renderEmails(emails);
             renderPageViewHistory(pageViews, sessionReferrer, pageViewOrderId, pageViewIsRedirected);
@@ -226,13 +238,71 @@ function renderOrderOverview(order: Order): void {
     }
 }
 
+function renderShipmentTracking(shipping: any): void {
+    section('2. SHIPMENT TRACKING');
+
+    if (!shipping) {
+        console.log('  No shipping address on file - this order may not have been a physical shipment.');
+        return;
+    }
+
+    const trackingDetails: any[] = shipping.tracking_number_details || [];
+    const plainTrackings: string[] = shipping.tracking_numbers || [];
+
+    if (trackingDetails.length > 0) {
+        // Rich tracking data - carrier, status, ETA, per-scan events.
+        trackingDetails.forEach((td, idx) => {
+            if (trackingDetails.length > 1) subsection(`Shipment ${idx + 1} of ${trackingDetails.length}`);
+
+            kv('Carrier',           td.shipping_method);
+            kv('Tracking #',        td.tracking_number);
+            const statusText = `${td.status || ''}  ${td.status_description || ''}`.trim();
+            kv('Status',            statusText || null);
+            kv('Tracking URL',      td.tracking_url);
+            kv('Shipped',           td.shipped_date_formatted           || td.shipped_date);
+            kv('Expected Delivery', td.expected_delivery_date_formatted || td.expected_delivery_date);
+            kv('Actual Delivery',   td.actual_delivery_date_formatted   || td.actual_delivery_date);
+
+            const events: any[] = td.details || [];
+            if (events.length === 0) {
+                console.log();
+                console.log('  No tracking events captured yet.');
+            } else {
+                subsection('Tracking Events');
+                // Most carriers feed events newest-first; preserve whatever order the API returned.
+                for (const ev of events) {
+                    const when = ev.event_dts || `${ev.event_local_date || ''} ${ev.event_local_time || ''}`.trim();
+                    const tag = ev.tag_description || ev.tag || '';
+                    const location = [ev.city, ev.state].filter(Boolean).join(', ');
+                    console.log(`  ${pad(when || '', 22)} ${pad(shorten(tag, 22), 22)} ${location}`);
+                    if (ev.subtag_message) console.log(`  ${' '.repeat(22)} ${ev.subtag_message}`);
+                }
+            }
+        });
+    } else if (plainTrackings.length > 0) {
+        // Feature not enabled (or carrier feed unavailable) - fall back to the
+        // plain tracking numbers we have on file.
+        console.log('  Detailed carrier scan data is not available for this order.');
+        console.log('  (Detailed tracking is an optional UltraCart feature that must be enabled');
+        console.log('  on the merchant account. Falling back to the plain tracking numbers below.)');
+        subsection('Tracking Numbers');
+        for (const tn of plainTrackings) console.log(`  ${tn}`);
+    } else {
+        console.log('  No shipment tracking on file for this order.');
+        console.log('  This is expected for digital goods, will-call/pickup orders, or orders');
+        console.log('  where tracking has not yet been posted by the carrier. Detailed carrier');
+        console.log('  scan data also requires the optional package-tracking feature to be');
+        console.log('  enabled on the merchant account.');
+    }
+}
+
 function renderSubscription(
     autoOrder: AutoOrder | undefined,
     rebillOrders: Order[],
     currentOrderId: string,
     autoOrderEmails: AutoOrderEmail[]
 ): void {
-    section('2. SUBSCRIPTION DETAILS');
+    section('3. SUBSCRIPTION DETAILS');
 
     if (!autoOrder) {
         console.log('  This order is NOT part of an auto order subscription.');
@@ -291,7 +361,7 @@ function renderSubscription(
 }
 
 function renderEmails(emails: OrderEmail[]): void {
-    section(`3. EMAIL DELIVERY (${emails.length} messages)`);
+    section(`4. EMAIL DELIVERY (${emails.length} messages)`);
     if (emails.length === 0) {
         console.log('  No email delivery records on file for this order.');
         return;
@@ -328,7 +398,7 @@ function renderPageViewHistory(
     sourceOrderId: string,
     isRedirected: boolean
 ): void {
-    section(`4. PAGE VIEW HISTORY (${pageViews.length} views)`);
+    section(`5. PAGE VIEW HISTORY (${pageViews.length} views)`);
     if (isRedirected) {
         console.log("  Note: this is a subscription rebill. The disputed order itself has no");
         console.log("  checkout session of its own. The page views below are from the ORIGINAL");


### PR DESCRIPTION
## Summary

Adds shipment-journey data (carrier, current status, ETA, per-scan event history) to the chargeback evidence sample in all 7 languages. Driven by a merchant request: shipment tracking is a key "proof of delivery" exhibit for "item not received" chargebacks, and the sample previously omitted it.

- Adds `shipping.tracking_number_details` to the explicit order expansion list.
- Inserts a new top-level **2. SHIPMENT TRACKING** section; renumbers Subscription/Email/Page-View to 3/4/5.
- Three render branches:
  1. Rich `tracking_number_details` populated → carrier, status, dates, tracking URL, and per-scan events with location.
  2. Only plain `tracking_numbers` available → falls back, notes the package-tracking feature is optional.
  3. Neither populated → friendly empty-state covering digital goods / pickup / not-yet-posted.
- Top-of-file docstring updated in each language to call out the OPTIONAL feature gate.

Also fixes two pre-existing PHP issues spotted while editing:
- `$email->getReportingMTA()` → `getReportingMta()` (matches Java and the SDK's lowercase-abbrev convention used for `Oid`, `Utm`, etc.)
- Aligns the PHP docstring bullet about `/emails` with the wording used by the other six languages.

Languages touched: Python, Ruby, C#, Java, JavaScript, TypeScript, PHP.

## Test plan

- [x] `python -m py_compile python/order/get_chargeback_evidence.py`
- [x] `ruby -c ruby/order/get_chargeback_evidence.rb`
- [x] `php -l php/order/getChargebackEvidence.php`
- [x] `node --check javascript/order/getChargebackEvidence.js`
- [x] `tsc --noEmit -p .` (TypeScript) — clean after refreshing `node_modules` to SDK 4.1.88
- [ ] Java + C# compile checks could not run locally (SDK artifacts not resolvable in this sandbox); build output showed zero errors attributed to the modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)