### PR TITLE
Add delay_auto_order_item sample (8 languages)

### DIFF
--- a/csharp/auto_order/DelayAutoOrderItem.cs
+++ b/csharp/auto_order/DelayAutoOrderItem.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using com.ultracart.admin.v2.Api;
+using com.ultracart.admin.v2.Model;
+
+namespace SdkSample.auto_order
+{
+    /// <summary>
+    /// DelayAutoOrderItem
+    ///
+    /// Delay one item's next shipment in an auto-order by N days.
+    ///
+    /// Fetch with expansion, mutate, persist. UltraCart does not support PATCH.
+    ///
+    /// This is the canonical pattern for editing an auto-order item in UltraCart:
+    ///
+    ///   1. GET the auto-order with the `items` expansion.
+    ///   2. Mutate the target item IN PLACE on the object returned by GET.
+    ///   3. PUT the full auto-order back.
+    ///   4. Re-GET and verify the change actually persisted.
+    ///
+    /// UltraCart does NOT support PATCH on auto-orders. Sending a stripped-down
+    /// item object on PUT is unsafe -- fields you omit (frequency, paused,
+    /// arbitrary_*, options, etc.) can be lost, and updates to items in unusual
+    /// states (e.g. mid free-trial) may silently no-op. Always echo the full
+    /// item objects as returned by GET, then mutate only the field(s) you intend
+    /// to change.
+    ///
+    /// Typical use case: a support bot or AI agent processing
+    ///     "please delay my next shipment by 30 days"
+    /// for a specific item in a multi-item auto-order.
+    /// </summary>
+    public class DelayAutoOrderItem
+    {
+        // Sample values. In a real integration these would come from the
+        // customer support request or AI agent context.
+        private const string ReferenceOrderId = "DEMO-0009103116"; // UltraCart order id that placed the auto-order
+        private const string ItemId           = "ITEM001";         // the original_item_id you want to delay
+        private const int    DelayDays        = 30;
+
+        // DoWork defaults to false (dry run). Flip to true to actually persist.
+        private const bool DoWork = false;
+
+        // How many days before the new shipment date to set the preshipment notice.
+        private const int PreshipmentNoticeLeadDays = 3;
+
+        public static void Execute()
+        {
+            Console.WriteLine("--- " + MethodBase.GetCurrentMethod()?.DeclaringType?.Name + " ---");
+
+            AutoOrderApi autoOrderApi = new AutoOrderApi(Constants.ApiKey);
+
+            // We need every field on every item so we can PUT them back unchanged.
+            string expand = "items";
+
+            // 1. Fetch the full auto-order with items expansion.
+            //
+            //    Alternative lookup: if you have the auto_order_code instead of the
+            //    reference order id, use:
+            //        autoOrderApi.GetAutoOrderByCode(autoOrderCode, expand);
+            AutoOrderResponse getResponse = autoOrderApi.GetAutoOrderByReferenceOrderId(ReferenceOrderId, expand);
+            AutoOrder autoOrder = getResponse.AutoOrder;
+            if (autoOrder == null)
+            {
+                Console.Error.WriteLine($"ERROR: No auto-order found for reference order {ReferenceOrderId}.");
+                return;
+            }
+
+            AutoOrderItem target = FindItem(autoOrder, ItemId);
+            if (target == null)
+            {
+                Console.Error.WriteLine($"ERROR: Item {ItemId} not found in auto-order for {ReferenceOrderId}.");
+                return;
+            }
+
+            string currentDtsStr = target.NextShipmentDts;
+            if (string.IsNullOrEmpty(currentDtsStr))
+            {
+                Console.Error.WriteLine($"ERROR: Item {ItemId} has no next_shipment_dts; nothing to delay.");
+                return;
+            }
+
+            DateTimeOffset currentDts = DateTimeOffset.Parse(
+                currentDtsStr, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+            DateTimeOffset now = DateTimeOffset.Now.ToOffset(currentDts.Offset);
+
+            // 2. Compute the new dates. If the stored next_shipment_dts is in the past
+            //    (which can happen for items mid-cycle or post-trial), anchoring the
+            //    delay to that stale date would leave the customer with a near-term
+            //    shipment, not the delay they asked for. Anchor to whichever is later:
+            //    the stored date, or now.
+            DateTimeOffset anchor = currentDts > now ? currentDts : now;
+            DateTimeOffset newShipmentDts = anchor.AddDays(DelayDays);
+            DateTimeOffset newNoticeDts   = newShipmentDts.AddDays(-PreshipmentNoticeLeadDays);
+
+            if (newNoticeDts <= now)
+            {
+                Console.Error.WriteLine(
+                    $"ERROR: Computed preshipment notice {IsoFmt(newNoticeDts)} is not in the future.");
+                return;
+            }
+
+            // 3. Mutate the target item IN PLACE. Do not rebuild the items array.
+            //    Every other field on the item (and every other item in the auto-order)
+            //    is preserved exactly as UltraCart returned it.
+            string newShipmentIso = IsoFmt(newShipmentDts);
+            string newNoticeIso   = IsoFmt(newNoticeDts);
+            target.NextShipmentDts          = newShipmentIso;
+            target.NextPreshipmentNoticeDts = newNoticeIso;
+
+            Console.WriteLine(new string('-', 60));
+            Console.WriteLine($"Reference order:      {ReferenceOrderId}");
+            Console.WriteLine($"Item:                 {ItemId}");
+            Console.WriteLine($"Current next ship:    {currentDtsStr}");
+            Console.WriteLine($"Proposed next ship:   {newShipmentIso}");
+            Console.WriteLine($"Proposed notice:      {newNoticeIso}");
+            if (currentDts < now)
+            {
+                Console.WriteLine("Note: stored next_shipment_dts was in the past; anchored delay to today.");
+            }
+            Console.WriteLine(new string('-', 60));
+
+            if (!DoWork)
+            {
+                Console.WriteLine("DRY RUN -- no changes persisted. Set DoWork = true to apply.");
+                return;
+            }
+
+            // 4. PUT the full auto-order back.
+            //    The C# SDK's UpdateAutoOrder takes (oid, autoOrder, validateOriginalOrder, expand).
+            //    "No" skips re-validation of the original order; an item-level date edit
+            //    doesn't need it.
+            string validateOriginalOrder = "No";
+            int autoOrderOid = autoOrder.AutoOrderOid;
+            AutoOrderResponse putResponse = autoOrderApi.UpdateAutoOrder(
+                autoOrderOid, autoOrder, validateOriginalOrder, expand);
+            AutoOrderItem putItem = FindItem(putResponse.AutoOrder, ItemId);
+            Console.WriteLine($"PUT response next_shipment_dts: {putItem?.NextShipmentDts}");
+
+            // 5. Re-GET and verify the change actually persisted. UltraCart can echo a
+            //    value back in the PUT response without it sticking for items in
+            //    unusual states. A fresh GET is the only way to know for sure.
+            AutoOrderResponse verifyResponse = autoOrderApi.GetAutoOrderByReferenceOrderId(ReferenceOrderId, expand);
+            AutoOrderItem verifyItem = FindItem(verifyResponse.AutoOrder, ItemId);
+            string verifiedDtsStr = verifyItem?.NextShipmentDts;
+
+            if (!string.IsNullOrEmpty(verifiedDtsStr)
+                && DateTimeOffset.TryParse(verifiedDtsStr, CultureInfo.InvariantCulture,
+                       DateTimeStyles.RoundtripKind, out DateTimeOffset verifiedDts)
+                && verifiedDts == newShipmentDts)
+            {
+                Console.WriteLine($"VERIFIED: next_shipment_dts persisted as {verifiedDtsStr}");
+                return;
+            }
+
+            Console.WriteLine(
+                $"WARNING: Re-GET shows next_shipment_dts = {verifiedDtsStr}, expected {newShipmentIso}.");
+            Console.WriteLine("The PUT was accepted by UltraCart but the value did not stick on re-read.");
+            Console.WriteLine("This commonly indicates the item is in a state UltraCart manages "
+                              + "automatically (e.g. mid free-trial). Escalate for human review.");
+        }
+
+        /// <summary>
+        /// Return the item with the given OriginalItemId, or null.
+        /// </summary>
+        private static AutoOrderItem FindItem(AutoOrder autoOrder, string itemId)
+        {
+            if (autoOrder == null) return null;
+            foreach (AutoOrderItem item in autoOrder.Items ?? new List<AutoOrderItem>())
+            {
+                if (string.Equals(item.OriginalItemId, itemId, StringComparison.Ordinal))
+                {
+                    return item;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Format a DateTimeOffset as UltraCart-style ISO 8601 with milliseconds and offset.
+        /// </summary>
+        private static string IsoFmt(DateTimeOffset dt)
+        {
+            return dt.ToString("yyyy-MM-ddTHH:mm:ss.fffzzz", CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/curl/auto_order/delayAutoOrderItem.curl
+++ b/curl/auto_order/delayAutoOrderItem.curl
@@ -1,0 +1,160 @@
+# Delay one item's next shipment in an auto-order
+
+**Fetch with expansion, mutate, persist. UltraCart does not support PATCH.**
+
+This sample walks through the canonical pattern for editing one item's shipment
+date inside an auto-order:
+
+1. GET the auto-order by reference order id with the `items` expansion.
+2. Mutate the target item IN PLACE (preserving every other field on every item).
+3. PUT the full auto-order back.
+4. Re-GET and verify the change actually persisted.
+
+Sending a stripped-down item object on PUT is unsafe -- fields you omit
+(`frequency`, `paused`, `arbitrary_*`, `options`, etc.) can be lost, and updates
+to items in unusual states (e.g. mid free-trial) may silently no-op. Always
+echo the full item objects as returned by GET, then mutate only the field(s)
+you intend to change.
+
+The examples below use `jq` for JSON manipulation and shell variables for the
+reference order id, target item id, and new dates. Replace the API key, ids,
+and dates with your own.
+
+Alternative lookup: if you have the auto_order_code instead of the original
+order id, swap the URL on step 1 to
+`/auto_order/auto_orders/code/{auto_order_code}` and rerun.
+
+---
+
+## Step 1 - GET the full auto-order by reference order id
+
+**Request \[[Create API Key](https://ultracart.atlassian.net/wiki/spaces/ucdoc/pages/38688545/API+Simple+Key)\]**
+```bash
+REFERENCE_ORDER_ID="DEMO-0009103116"
+ITEM_ID="ITEM001"
+SIMPLE_KEY="<your simple key>"
+
+curl -X GET "https://secure.ultracart.com/rest/v2/auto_order/auto_orders/reference_order_id/${REFERENCE_ORDER_ID}?_expand=items" \
+  -H "Accept: application/json" \
+  -H "X-UltraCart-Api-Version: 2017-03-01" \
+  -H "x-ultracart-simple-key: ${SIMPLE_KEY}" \
+  -o auto_order.json
+```
+
+**Response Body** (saved to `auto_order.json`)
+```json
+{
+    "auto_order": {
+        "auto_order_oid": 5712848,
+        "original_order_id": "DEMO-0009103116",
+        "auto_order_code": "6N8DKS6VTF",
+        "enabled": true,
+        "items": [
+            {
+                "auto_order_item_oid": 101036395,
+                "original_item_id": "ITEM001",
+                "original_quantity": 1,
+                "next_shipment_dts": "2026-06-14T00:00:00-04:00",
+                "next_preshipment_notice_dts": "2026-06-11T00:00:00-04:00",
+                "frequency": "Monthly",
+                "options": [],
+                "future_schedules": []
+            }
+        ]
+    },
+    "success": true
+}
+```
+
+---
+
+## Step 2 - Mutate the target item in place
+
+Add 30 days to the target item's `next_shipment_dts` and 27 days for the
+preshipment notice (3 days before shipment). `jq` walks every item but only
+updates fields on the one whose `original_item_id` matches; every other item
+and every other field on the target item passes through untouched.
+
+```bash
+NEW_SHIPMENT_DTS=$(date -d "$(jq -r --arg id "$ITEM_ID" \
+    '.auto_order.items[] | select(.original_item_id == $id) | .next_shipment_dts' \
+    auto_order.json) + 30 days" --iso-8601=seconds)
+
+NEW_NOTICE_DTS=$(date -d "${NEW_SHIPMENT_DTS} - 3 days" --iso-8601=seconds)
+
+jq --arg id "$ITEM_ID" \
+   --arg ship "$NEW_SHIPMENT_DTS" \
+   --arg notice "$NEW_NOTICE_DTS" \
+   '.auto_order.items |= map(
+       if .original_item_id == $id then
+           .next_shipment_dts = $ship
+         | .next_preshipment_notice_dts = $notice
+       else .
+       end
+   )' auto_order.json > auto_order_modified.json
+```
+
+The critical bit: `map(if matches then mutate else . end)`. The `else .` clause
+echoes the item unchanged. Do NOT rebuild the items array with just three or
+four fields per item; that is the sparse-PUT mistake that loses data on
+fields you didn't intend to touch.
+
+---
+
+## Step 3 - PUT the full auto-order
+
+The PUT body is the entire `auto_order` object exactly as we received it,
+with only the two date fields on the target item changed.
+
+**Request**
+```bash
+AUTO_ORDER_OID=$(jq -r '.auto_order.auto_order_oid' auto_order_modified.json)
+
+curl -X PUT "https://secure.ultracart.com/rest/v2/auto_order/auto_orders/${AUTO_ORDER_OID}?validate_original_order=No&_expand=items" \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  -H "X-UltraCart-Api-Version: 2017-03-01" \
+  -H "x-ultracart-simple-key: ${SIMPLE_KEY}" \
+  -d @<(jq '.auto_order' auto_order_modified.json)
+```
+
+**Response Body** (truncated)
+```json
+{
+    "auto_order": {
+        "auto_order_oid": 5712848,
+        "items": [
+            {
+                "auto_order_item_oid": 101036395,
+                "original_item_id": "ITEM001",
+                "next_shipment_dts": "2026-07-14T00:00:00-04:00",
+                "next_preshipment_notice_dts": "2026-07-11T00:00:00-04:00",
+                "frequency": "Monthly"
+            }
+        ]
+    },
+    "success": true
+}
+```
+
+---
+
+## Step 4 - Re-GET and verify
+
+Critical step. UltraCart can echo a value back in the PUT response without it
+sticking for items in unusual states (e.g. mid free-trial). A fresh GET is
+the only way to know the change persisted.
+
+```bash
+curl -s -X GET "https://secure.ultracart.com/rest/v2/auto_order/auto_orders/reference_order_id/${REFERENCE_ORDER_ID}?_expand=items" \
+  -H "Accept: application/json" \
+  -H "X-UltraCart-Api-Version: 2017-03-01" \
+  -H "x-ultracart-simple-key: ${SIMPLE_KEY}" \
+| jq --arg id "$ITEM_ID" --arg expected "$NEW_SHIPMENT_DTS" '
+    (.auto_order.items[] | select(.original_item_id == $id) | .next_shipment_dts) as $actual
+    | if $actual == $expected
+      then "VERIFIED: next_shipment_dts persisted as " + $actual
+      else "WARNING: Re-GET shows next_shipment_dts = " + $actual + ", expected " + $expected + ".\nThe PUT was accepted but the value did not stick on re-read.\nThis commonly indicates the item is in a state UltraCart manages automatically (e.g. mid free-trial). Escalate for human review."
+      end
+'
+```

--- a/java/src/auto_order/DelayAutoOrderItem.java
+++ b/java/src/auto_order/DelayAutoOrderItem.java
@@ -1,0 +1,178 @@
+package auto_order;
+
+import com.ultracart.admin.v2.AutoOrderApi;
+import com.ultracart.admin.v2.models.*;
+import com.ultracart.admin.v2.util.ApiException;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.util.List;
+
+/**
+ * Delay one item's next shipment in an auto-order by N days.
+ *
+ * Fetch with expansion, mutate, persist. UltraCart does NOT support PATCH.
+ *
+ * This is the canonical pattern for editing an auto-order item in UltraCart:
+ *
+ *     1. GET the auto-order with the `items` expansion.
+ *     2. Mutate the target item IN PLACE on the object returned by GET.
+ *     3. PUT the full auto-order back.
+ *     4. Re-GET and verify the change actually persisted.
+ *
+ * Sending a stripped-down item object on PUT is unsafe -- fields you omit
+ * (frequency, paused, arbitrary_*, options, etc.) can be lost, and updates to
+ * items in unusual states (e.g. mid free-trial) may silently no-op. Always
+ * echo the full item objects as returned by GET, then mutate only the
+ * field(s) you intend to change.
+ *
+ * Typical use case: a support bot or AI agent processing
+ *     "please delay my next shipment by 30 days"
+ * for a specific item in a multi-item auto-order.
+ */
+public class DelayAutoOrderItem {
+
+    // Sample values. In a real integration these would come from the customer
+    // support request or AI agent context.
+    private static final String REFERENCE_ORDER_ID = "DEMO-0009103116"; // UltraCart order id that placed the auto-order
+    private static final String ITEM_ID            = "ITEM001";         // the original_item_id you want to delay
+    private static final int    DELAY_DAYS         = 30;
+
+    // DRY_RUN defaults to true. Set to false to actually persist the change.
+    private static final boolean DRY_RUN = true;
+
+    // How many days before the new shipment date to set the preshipment notice.
+    private static final int PRESHIPMENT_NOTICE_LEAD_DAYS = 3;
+
+    // ISO 8601 with millisecond precision and offset, matching the format
+    // UltraCart returns on GET (e.g. 2026-05-19T10:30:00.123-04:00).
+    private static final DateTimeFormatter ISO_MILLIS = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+            .appendFraction(ChronoField.MILLI_OF_SECOND, 3, 3, true)
+            .appendOffset("+HH:MM", "+00:00")
+            .toFormatter();
+
+    public static void execute() {
+        System.out.println("--- " + DelayAutoOrderItem.class.getSimpleName() + " ---");
+
+        AutoOrderApi autoOrderApi = new AutoOrderApi(common.Constants.API_KEY);
+        String expand = "items"; // see https://www.ultracart.com/api/#resource_auto_order.html for list
+
+        try {
+            // 1. Fetch the full auto-order with items expansion. We need every field on
+            //    every item so we can PUT them back unchanged.
+            //
+            //    Alternative lookup: if you have the auto_order_code instead of the
+            //    reference order id, use:
+            //        autoOrderApi.getAutoOrderByCode(autoOrderCode, expand);
+            AutoOrderResponse getResponse = autoOrderApi.getAutoOrderByReferenceOrderId(REFERENCE_ORDER_ID, expand);
+            AutoOrder autoOrder = getResponse.getAutoOrder();
+            if (autoOrder == null) {
+                System.err.println("ERROR: No auto-order found for reference order " + REFERENCE_ORDER_ID + ".");
+                return;
+            }
+
+            AutoOrderItem target = findItem(autoOrder, ITEM_ID);
+            if (target == null) {
+                System.err.println("ERROR: Item " + ITEM_ID + " not found in auto-order for " + REFERENCE_ORDER_ID + ".");
+                return;
+            }
+
+            String currentDtsStr = target.getNextShipmentDts();
+            if (currentDtsStr == null || currentDtsStr.isEmpty()) {
+                System.err.println("ERROR: Item " + ITEM_ID + " has no next_shipment_dts; nothing to delay.");
+                return;
+            }
+
+            OffsetDateTime currentDts = OffsetDateTime.parse(currentDtsStr);
+            OffsetDateTime now = OffsetDateTime.now(ZoneId.systemDefault())
+                                               .withOffsetSameInstant(currentDts.getOffset());
+
+            // 2. Compute the new dates. If the stored next_shipment_dts is in the past
+            //    (which can happen for items mid-cycle or post-trial), anchoring the
+            //    delay to that stale date would leave the customer with a near-term
+            //    shipment, not the delay they asked for. Anchor to whichever is later:
+            //    the stored date, or now.
+            OffsetDateTime anchor = currentDts.isAfter(now) ? currentDts : now;
+            OffsetDateTime newShipmentDts = anchor.plusDays(DELAY_DAYS);
+            OffsetDateTime newNoticeDts   = newShipmentDts.minusDays(PRESHIPMENT_NOTICE_LEAD_DAYS);
+
+            if (!newNoticeDts.isAfter(now)) {
+                System.err.println("ERROR: Computed preshipment notice " + ISO_MILLIS.format(newNoticeDts)
+                                   + " is not in the future.");
+                return;
+            }
+
+            // 3. Mutate the target item IN PLACE. Do not rebuild the items list.
+            //    Every other field on the item (and every other item in the auto-order)
+            //    is preserved exactly as UltraCart returned it.
+            String newShipmentIso = ISO_MILLIS.format(newShipmentDts);
+            String newNoticeIso   = ISO_MILLIS.format(newNoticeDts);
+            target.setNextShipmentDts(newShipmentIso);
+            target.setNextPreshipmentNoticeDts(newNoticeIso);
+
+            System.out.println("------------------------------------------------------------");
+            System.out.println("Reference order:      " + REFERENCE_ORDER_ID);
+            System.out.println("Item:                 " + ITEM_ID);
+            System.out.println("Current next ship:    " + currentDtsStr);
+            System.out.println("Proposed next ship:   " + newShipmentIso);
+            System.out.println("Proposed notice:      " + newNoticeIso);
+            if (currentDts.isBefore(now)) {
+                System.out.println("Note: stored next_shipment_dts was in the past; anchored delay to today.");
+            }
+            System.out.println("------------------------------------------------------------");
+
+            if (DRY_RUN) {
+                System.out.println("DRY RUN -- no changes persisted. Set DRY_RUN = false to apply.");
+                return;
+            }
+
+            // 4. PUT the full auto-order back.
+            Integer autoOrderOid = autoOrder.getAutoOrderOid();
+            String validateOriginalOrder = "No";
+            AutoOrderResponse putResponse = autoOrderApi.updateAutoOrder(
+                    autoOrderOid, autoOrder, validateOriginalOrder, expand);
+            AutoOrderItem putItem = findItem(putResponse.getAutoOrder(), ITEM_ID);
+            System.out.println("PUT response next_shipment_dts: "
+                               + (putItem != null ? putItem.getNextShipmentDts() : "(item not in response)"));
+
+            // 5. Re-GET and verify the change actually persisted. UltraCart can echo a
+            //    value back in the PUT response without it sticking for items in
+            //    unusual states. A fresh GET is the only way to know for sure.
+            AutoOrderResponse verifyResponse = autoOrderApi.getAutoOrderByReferenceOrderId(REFERENCE_ORDER_ID, expand);
+            AutoOrderItem verifyItem = findItem(verifyResponse.getAutoOrder(), ITEM_ID);
+            String verifiedDtsStr = verifyItem != null ? verifyItem.getNextShipmentDts() : null;
+
+            if (verifiedDtsStr != null
+                    && OffsetDateTime.parse(verifiedDtsStr).isEqual(newShipmentDts)) {
+                System.out.println("VERIFIED: next_shipment_dts persisted as " + verifiedDtsStr);
+                return;
+            }
+
+            System.out.println("WARNING: Re-GET shows next_shipment_dts = " + verifiedDtsStr
+                               + ", expected " + newShipmentIso + ".");
+            System.out.println("The PUT was accepted by UltraCart but the value did not stick on re-read.");
+            System.out.println("This commonly indicates the item is in a state UltraCart manages "
+                               + "automatically (e.g. mid free-trial). Escalate for human review.");
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AutoOrderApi: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    /** Return the item with the given original_item_id, or null. */
+    private static AutoOrderItem findItem(AutoOrder autoOrder, String itemId) {
+        if (autoOrder == null) return null;
+        List<AutoOrderItem> items = autoOrder.getItems();
+        if (items == null) return null;
+        for (AutoOrderItem item : items) {
+            if (itemId.equals(item.getOriginalItemId())) {
+                return item;
+            }
+        }
+        return null;
+    }
+}

--- a/javascript/auto_order/delayAutoOrderItem.js
+++ b/javascript/auto_order/delayAutoOrderItem.js
@@ -1,0 +1,203 @@
+import { autoOrderApi } from '../api.js';
+
+/**
+ * delayAutoOrderItem
+ *
+ * Delays one item's next shipment in an auto-order by N days.
+ *
+ * Fetch with expansion, mutate, persist. UltraCart does not support PATCH.
+ *
+ * This is the canonical pattern for editing an auto-order item in UltraCart:
+ *
+ *   1. GET the auto-order with the items expansion.
+ *   2. Mutate the target item IN PLACE on the object returned by GET.
+ *   3. PUT the full auto-order back.
+ *   4. Re-GET and verify the change actually persisted.
+ *
+ * Sending a stripped-down item object on PUT is unsafe -- fields you omit
+ * (frequency, paused, arbitrary_*, options, etc.) can be lost, and updates
+ * to items in unusual states (e.g. mid free-trial) may silently no-op.
+ * Always echo the full item objects as returned by GET, then mutate only
+ * the field(s) you intend to change.
+ *
+ * Typical use case: a support bot or AI agent processing
+ *     "please delay my next shipment by 30 days"
+ * for a specific item in a multi-item auto-order.
+ */
+
+// Sample values. In a real integration these would come from the customer
+// support request or AI agent context.
+const REFERENCE_ORDER_ID = 'DEMO-0009103116'; // UltraCart order id that placed the auto-order
+const ITEM_ID            = 'ITEM001';         // the original_item_id you want to delay
+const DELAY_DAYS         = 30;
+
+// DO_WORK defaults to false (dry run). Flip to true to actually persist.
+const DO_WORK = false;
+
+// How many days before the new shipment date to set the preshipment notice.
+const PRESHIPMENT_NOTICE_LEAD_DAYS = 3;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export async function execute() {
+    const expand = 'items';
+
+    try {
+        // 1. Fetch the full auto-order with items expansion. We need every
+        //    field on every item so we can PUT them back unchanged.
+        //
+        //    Alternative lookup: if you have the auto_order_code instead of
+        //    the reference order id, use autoOrderApi.getAutoOrderByCode.
+        const getResponse = await new Promise((resolve, reject) => {
+            autoOrderApi.getAutoOrderByReferenceOrderId(REFERENCE_ORDER_ID, { _expand: expand }, function (error, data) {
+                if (error) reject(error);
+                else resolve(data);
+            });
+        });
+
+        const autoOrder = getResponse.auto_order;
+        if (!autoOrder) {
+            console.error('ERROR: No auto-order found for reference order ' + REFERENCE_ORDER_ID + '.');
+            return;
+        }
+
+        const target = findItem(autoOrder, ITEM_ID);
+        if (!target) {
+            console.error('ERROR: Item ' + ITEM_ID + ' not found in auto-order for ' + REFERENCE_ORDER_ID + '.');
+            return;
+        }
+
+        const currentDtsStr = target.next_shipment_dts;
+        if (!currentDtsStr) {
+            console.error('ERROR: Item ' + ITEM_ID + ' has no next_shipment_dts; nothing to delay.');
+            return;
+        }
+
+        const currentDts = new Date(currentDtsStr);
+        if (isNaN(currentDts.getTime())) {
+            console.error('ERROR: Could not parse next_shipment_dts "' + currentDtsStr + '".');
+            return;
+        }
+        const now = new Date();
+
+        // 2. Compute the new dates. If the stored next_shipment_dts is in the
+        //    past (which can happen for items mid-cycle or post-trial),
+        //    anchoring the delay to that stale date would leave the customer
+        //    with a near-term shipment, not the delay they asked for. Anchor
+        //    to whichever is later: the stored date, or now.
+        const anchor = currentDts.getTime() > now.getTime() ? currentDts : now;
+        const newShipmentDts = new Date(anchor.getTime() + DELAY_DAYS * MS_PER_DAY);
+        const newNoticeDts = new Date(newShipmentDts.getTime() - PRESHIPMENT_NOTICE_LEAD_DAYS * MS_PER_DAY);
+
+        if (newNoticeDts.getTime() <= now.getTime()) {
+            console.error('ERROR: Computed preshipment notice ' + isoFmt(newNoticeDts) + ' is not in the future.');
+            return;
+        }
+
+        // 3. Mutate the target item IN PLACE. Do not rebuild the items array.
+        //    Every other field on the item (and every other item in the
+        //    auto-order) is preserved exactly as UltraCart returned it.
+        const newShipmentIso = isoFmt(newShipmentDts);
+        const newNoticeIso = isoFmt(newNoticeDts);
+        target.next_shipment_dts = newShipmentIso;
+        target.next_preshipment_notice_dts = newNoticeIso;
+
+        console.log('-'.repeat(60));
+        console.log('Reference order:      ' + REFERENCE_ORDER_ID);
+        console.log('Item:                 ' + ITEM_ID);
+        console.log('Current next ship:    ' + currentDtsStr);
+        console.log('Proposed next ship:   ' + newShipmentIso);
+        console.log('Proposed notice:      ' + newNoticeIso);
+        if (currentDts.getTime() < now.getTime()) {
+            console.log('Note: stored next_shipment_dts was in the past; anchored delay to today.');
+        }
+        console.log('-'.repeat(60));
+
+        if (!DO_WORK) {
+            console.log('DRY RUN -- no changes persisted. Set DO_WORK = true to apply.');
+            return;
+        }
+
+        // 4. PUT the full auto-order back.
+        const putResponse = await new Promise((resolve, reject) => {
+            autoOrderApi.updateAutoOrder(
+                autoOrder.auto_order_oid,
+                autoOrder,
+                { _expand: expand },
+                function (error, data) {
+                    if (error) reject(error);
+                    else resolve(data);
+                }
+            );
+        });
+
+        const putItem = findItem(putResponse.auto_order, ITEM_ID);
+        console.log('PUT response next_shipment_dts: ' + (putItem ? putItem.next_shipment_dts : '(item not in response)'));
+
+        // 5. Re-GET and verify the change actually persisted. UltraCart can
+        //    echo a value back in the PUT response without it sticking for
+        //    items in unusual states. A fresh GET is the only way to know
+        //    for sure.
+        const verifyResponse = await new Promise((resolve, reject) => {
+            autoOrderApi.getAutoOrderByReferenceOrderId(REFERENCE_ORDER_ID, { _expand: expand }, function (error, data) {
+                if (error) reject(error);
+                else resolve(data);
+            });
+        });
+
+        const verifyItem = findItem(verifyResponse.auto_order, ITEM_ID);
+        const verifiedDtsStr = verifyItem ? verifyItem.next_shipment_dts : null;
+
+        if (verifiedDtsStr && new Date(verifiedDtsStr).getTime() === newShipmentDts.getTime()) {
+            console.log('VERIFIED: next_shipment_dts persisted as ' + verifiedDtsStr);
+            return;
+        }
+
+        console.warn('WARNING: Re-GET shows next_shipment_dts = ' + verifiedDtsStr + ', expected ' + newShipmentIso + '.');
+        console.warn('The PUT was accepted by UltraCart but the value did not stick on re-read.');
+        console.warn('This commonly indicates the item is in a state UltraCart manages '
+            + 'automatically (e.g. mid free-trial). Escalate for human review.');
+    } catch (error) {
+        console.error('Error: ' + (error instanceof Error ? error.message : 'Unknown error'));
+        console.error(error instanceof Error ? error.stack : error);
+    }
+}
+
+function findItem(autoOrder, itemId) {
+    const items = (autoOrder && autoOrder.items) || [];
+    for (const item of items) {
+        if (item.original_item_id === itemId) {
+            return item;
+        }
+    }
+    return null;
+}
+
+/**
+ * Format a Date as UltraCart-style ISO 8601 with milliseconds in local time
+ * with a numeric timezone offset (e.g. 2026-06-18T09:15:00.000-04:00).
+ *
+ * Date#toISOString() always emits UTC with a trailing 'Z'; the Python
+ * reference emits a local offset, which is what the API returns on GET.
+ */
+function isoFmt(dt) {
+    const pad2 = (n) => String(n).padStart(2, '0');
+    const pad3 = (n) => String(n).padStart(3, '0');
+
+    const year    = dt.getFullYear();
+    const month   = pad2(dt.getMonth() + 1);
+    const day     = pad2(dt.getDate());
+    const hours   = pad2(dt.getHours());
+    const minutes = pad2(dt.getMinutes());
+    const seconds = pad2(dt.getSeconds());
+    const millis  = pad3(dt.getMilliseconds());
+
+    const offsetMin = -dt.getTimezoneOffset();
+    const sign      = offsetMin >= 0 ? '+' : '-';
+    const offsetAbs = Math.abs(offsetMin);
+    const offH      = pad2(Math.floor(offsetAbs / 60));
+    const offM      = pad2(offsetAbs % 60);
+
+    return year + '-' + month + '-' + day + 'T' + hours + ':' + minutes + ':' + seconds + '.' + millis + sign + offH + ':' + offM;
+}
+
+execute().catch(console.error);

--- a/php/auto_order/delayAutoOrderItem.php
+++ b/php/auto_order/delayAutoOrderItem.php
@@ -1,0 +1,178 @@
+<?php
+/*
+ * delayAutoOrderItem.php
+ *
+ * Delay one item's next shipment in an auto-order by N days.
+ *
+ * Fetch with expansion, mutate, persist. UltraCart does not support PATCH.
+ *
+ * This is the canonical pattern for editing an auto-order item in UltraCart:
+ *
+ *   1. GET the auto-order with the `items` expansion.
+ *   2. Mutate the target item IN PLACE on the object returned by GET.
+ *   3. PUT the full auto-order back.
+ *   4. Re-GET and verify the change actually persisted.
+ *
+ * UltraCart does NOT support PATCH on auto-orders. Sending a stripped-down
+ * item object on PUT is unsafe -- fields you omit (frequency, paused,
+ * arbitrary_*, options, etc.) can be lost, and updates to items in unusual
+ * states (e.g. mid free-trial) may silently no-op. Always echo the full
+ * item objects as returned by GET, then mutate only the field(s) you intend
+ * to change.
+ *
+ * Typical use case: a support bot or AI agent processing
+ *     "please delay my next shipment by 30 days"
+ * for a specific item in a multi-item auto-order.
+ */
+
+ini_set('display_errors', 1);
+
+require_once '../vendor/autoload.php';
+require_once '../samples.php';
+
+// Sample values. In a real integration these would come from the customer
+// support request or AI agent context.
+const REFERENCE_ORDER_ID = 'DEMO-0009103116'; // UltraCart order id that placed the auto-order
+const ITEM_ID            = 'ITEM001';         // the original_item_id you want to delay
+const DELAY_DAYS         = 30;
+
+// DO_WORK defaults to false (dry run). Flip to true to actually persist.
+const DO_WORK = false;
+
+// How many days before the new shipment date to set the preshipment notice.
+const PRESHIPMENT_NOTICE_LEAD_DAYS = 3;
+
+
+$auto_order_api = Samples::getAutoOrderApi();
+$expand = 'items';
+
+// 1. Fetch the full auto-order with items expansion. We need every field on
+//    every item so we can PUT them back unchanged.
+//
+//    Alternative lookup: if you have the auto_order_code instead of the
+//    reference order id, use:
+//        $auto_order_api->getAutoOrderByCode($auto_order_code, $expand);
+$response = $auto_order_api->getAutoOrderByReferenceOrderId(REFERENCE_ORDER_ID, $expand);
+if ($response->getError() !== null) {
+    fail('getAutoOrderByReferenceOrderId', $response->getError());
+}
+$auto_order = $response->getAutoOrder();
+if ($auto_order === null) {
+    fwrite(STDERR, "ERROR: No auto-order found for reference order " . REFERENCE_ORDER_ID . ".\n");
+    exit(1);
+}
+
+$target = findItem($auto_order, ITEM_ID);
+if ($target === null) {
+    fwrite(STDERR, "ERROR: Item " . ITEM_ID . " not found in auto-order for " . REFERENCE_ORDER_ID . ".\n");
+    exit(1);
+}
+
+$current_dts_str = $target->getNextShipmentDts();
+if ($current_dts_str === null || $current_dts_str === '') {
+    fwrite(STDERR, "ERROR: Item " . ITEM_ID . " has no next_shipment_dts; nothing to delay.\n");
+    exit(1);
+}
+
+$current_dts = new DateTime($current_dts_str);
+$now         = new DateTime('now', $current_dts->getTimezone());
+
+// 2. Compute the new dates. If the stored next_shipment_dts is in the past
+//    (which can happen for items mid-cycle or post-trial), anchoring the
+//    delay to that stale date would leave the customer with a near-term
+//    shipment, not the delay they asked for. Anchor to whichever is later:
+//    the stored date, or now.
+$anchor = $current_dts > $now ? clone $current_dts : clone $now;
+$new_shipment_dts = (clone $anchor)->modify('+' . DELAY_DAYS . ' days');
+$new_notice_dts   = (clone $new_shipment_dts)->modify('-' . PRESHIPMENT_NOTICE_LEAD_DAYS . ' days');
+
+if ($new_notice_dts <= $now) {
+    fwrite(STDERR, "ERROR: Computed preshipment notice " . isofmt($new_notice_dts) . " is not in the future.\n");
+    exit(1);
+}
+
+// 3. Mutate the target item IN PLACE. Do not rebuild the items array.
+//    Every other field on the item (and every other item in the auto-order)
+//    is preserved exactly as UltraCart returned it.
+$new_shipment_iso = isofmt($new_shipment_dts);
+$new_notice_iso   = isofmt($new_notice_dts);
+$target->setNextShipmentDts($new_shipment_iso);
+$target->setNextPreshipmentNoticeDts($new_notice_iso);
+
+echo str_repeat('-', 60) . "\n";
+echo "Reference order:      " . REFERENCE_ORDER_ID . "\n";
+echo "Item:                 " . ITEM_ID . "\n";
+echo "Current next ship:    {$current_dts_str}\n";
+echo "Proposed next ship:   {$new_shipment_iso}\n";
+echo "Proposed notice:      {$new_notice_iso}\n";
+if ($current_dts < $now) {
+    echo "Note: stored next_shipment_dts was in the past; anchored delay to today.\n";
+}
+echo str_repeat('-', 60) . "\n";
+
+if (!DO_WORK) {
+    echo "DRY RUN -- no changes persisted. Set DO_WORK = true to apply.\n";
+    exit(0);
+}
+
+// 4. PUT the full auto-order back.
+//    The PHP SDK's updateAutoOrder takes (oid, auto_order, validate_original_order, _expand).
+//    "No" skips re-validation of the original order; an item-level date edit doesn't need it.
+$put_response = $auto_order_api->updateAutoOrder(
+    $auto_order->getAutoOrderOid(), $auto_order, 'No', $expand);
+if ($put_response->getError() !== null) {
+    fail('updateAutoOrder', $put_response->getError());
+}
+$put_item = findItem($put_response->getAutoOrder(), ITEM_ID);
+echo "PUT response next_shipment_dts: " . ($put_item !== null ? $put_item->getNextShipmentDts() : '(item not in response)') . "\n";
+
+// 5. Re-GET and verify the change actually persisted. UltraCart can echo a
+//    value back in the PUT response without it sticking for items in
+//    unusual states. A fresh GET is the only way to know for sure.
+$verify_response = $auto_order_api->getAutoOrderByReferenceOrderId(REFERENCE_ORDER_ID, $expand);
+if ($verify_response->getError() !== null) {
+    fail('getAutoOrderByReferenceOrderId (verify)', $verify_response->getError());
+}
+$verify_item = findItem($verify_response->getAutoOrder(), ITEM_ID);
+$verified_dts_str = $verify_item !== null ? $verify_item->getNextShipmentDts() : null;
+
+if ($verified_dts_str !== null
+    && (new DateTime($verified_dts_str)) == $new_shipment_dts) {
+    echo "VERIFIED: next_shipment_dts persisted as {$verified_dts_str}\n";
+    exit(0);
+}
+
+echo "WARNING: Re-GET shows next_shipment_dts = " . ($verified_dts_str ?? '(null)')
+   . ", expected {$new_shipment_iso}.\n";
+echo "The PUT was accepted by UltraCart but the value did not stick on re-read.\n";
+echo "This commonly indicates the item is in a state UltraCart manages "
+   . "automatically (e.g. mid free-trial). Escalate for human review.\n";
+exit(2);
+
+
+// =====================================================================
+// Helpers
+// =====================================================================
+
+function findItem($auto_order, string $item_id) {
+    if ($auto_order === null) return null;
+    foreach ($auto_order->getItems() ?? [] as $item) {
+        if ($item->getOriginalItemId() === $item_id) {
+            return $item;
+        }
+    }
+    return null;
+}
+
+function isofmt(DateTime $dt): string {
+    // Matches Python's astimezone().isoformat('T', 'milliseconds'):
+    //   yyyy-MM-ddTHH:mm:ss.fff+HH:MM
+    return $dt->format('Y-m-d\\TH:i:s.000P');
+}
+
+function fail(string $operation, $error): void {
+    fwrite(STDERR, "ERROR in {$operation}:\n");
+    fwrite(STDERR, "  Developer message: " . ($error->getDeveloperMessage() ?? '') . "\n");
+    fwrite(STDERR, "  User message:      " . ($error->getUserMessage() ?? '') . "\n");
+    exit(1);
+}

--- a/python/auto_order/delay_auto_order_item.py
+++ b/python/auto_order/delay_auto_order_item.py
@@ -1,0 +1,150 @@
+"""
+Delay one item's next shipment in an auto-order by N days.
+
+Fetch with expansion, mutate, persist. UltraCart does not support PATCH.
+
+This is the canonical pattern for editing an auto-order item in UltraCart:
+
+    1. GET the auto-order with the `items` expansion.
+    2. Mutate the target item IN PLACE on the object returned by GET.
+    3. PUT the full auto-order back.
+    4. Re-GET and verify the change actually persisted.
+
+UltraCart does NOT support PATCH on auto-orders. Sending a stripped-down item
+object on PUT is unsafe -- fields you omit (frequency, paused, arbitrary_*,
+options, etc.) can be lost, and updates to items in unusual states (e.g.
+mid free-trial) may silently no-op. Always echo the full item objects as
+returned by GET, then mutate only the field(s) you intend to change.
+
+Typical use case: a support bot or AI agent processing
+    "please delay my next shipment by 30 days"
+for a specific item in a multi-item auto-order.
+"""
+
+from datetime import datetime, timedelta
+
+from ultracart.apis import AutoOrderApi
+from samples import api_client
+
+
+# Sample values. In a real integration these would come from the customer
+# support request or AI agent context.
+REFERENCE_ORDER_ID = "DEMO-0009103116"   # UltraCart order id that placed the auto-order
+ITEM_ID            = "ITEM001"           # the original_item_id you want to delay
+DELAY_DAYS         = 30
+
+# DO_WORK defaults to False (dry run). Flip to True to actually persist.
+DO_WORK = False
+
+# How many days before the new shipment date to set the preshipment notice.
+PRESHIPMENT_NOTICE_LEAD_DAYS = 3
+
+
+def delay_auto_order_item():
+    auto_order_api = AutoOrderApi(api_client())
+
+    # 1. Fetch the full auto-order with items expansion. We need every field on
+    #    every item so we can PUT them back unchanged.
+    #
+    #    Alternative lookup: if you have the auto_order_code instead of the
+    #    original order id, use:
+    #        auto_order_api.get_auto_order_by_code(auto_order_code, expand=expand)
+    expand = "items"
+    response = auto_order_api.get_auto_order_by_reference_order_id(
+        REFERENCE_ORDER_ID, expand=expand)
+    auto_order = response.auto_order
+    if auto_order is None:
+        print(f"ERROR: No auto-order found for reference order {REFERENCE_ORDER_ID}.")
+        return
+
+    target = _find_item(auto_order, ITEM_ID)
+    if target is None:
+        print(f"ERROR: Item {ITEM_ID} not found in auto-order for {REFERENCE_ORDER_ID}.")
+        return
+
+    current_dts_str = target.next_shipment_dts
+    if not current_dts_str:
+        print(f"ERROR: Item {ITEM_ID} has no next_shipment_dts; nothing to delay.")
+        return
+
+    current_dts = datetime.fromisoformat(current_dts_str)
+    now = datetime.now(current_dts.tzinfo)
+
+    # 2. Compute the new dates. If the stored next_shipment_dts is in the past
+    #    (which can happen for items mid-cycle or post-trial), anchoring the
+    #    delay to that stale date would leave the customer with a near-term
+    #    shipment, not the delay they asked for. Anchor to whichever is later:
+    #    the stored date, or now.
+    anchor = max(current_dts, now)
+    new_shipment_dts = anchor + timedelta(days=DELAY_DAYS)
+    new_notice_dts = new_shipment_dts - timedelta(days=PRESHIPMENT_NOTICE_LEAD_DAYS)
+
+    if new_notice_dts <= now:
+        print(f"ERROR: Computed preshipment notice {_isofmt(new_notice_dts)} is not in the future.")
+        return
+
+    # 3. Mutate the target item IN PLACE. Do not rebuild the items array.
+    #    Every other field on the item (and every other item in the auto-order)
+    #    is preserved exactly as UltraCart returned it.
+    new_shipment_iso = _isofmt(new_shipment_dts)
+    new_notice_iso = _isofmt(new_notice_dts)
+    target.next_shipment_dts = new_shipment_iso
+    target.next_preshipment_notice_dts = new_notice_iso
+
+    print("-" * 60)
+    print(f"Reference order:      {REFERENCE_ORDER_ID}")
+    print(f"Item:                 {ITEM_ID}")
+    print(f"Current next ship:    {current_dts_str}")
+    print(f"Proposed next ship:   {new_shipment_iso}")
+    print(f"Proposed notice:      {new_notice_iso}")
+    if current_dts < now:
+        print("Note: stored next_shipment_dts was in the past; anchored delay to today.")
+    print("-" * 60)
+
+    if not DO_WORK:
+        print("DRY RUN -- no changes persisted. Set DO_WORK = True to apply.")
+        return
+
+    # 4. PUT the full auto-order back.
+    put_response = auto_order_api.update_auto_order(
+        auto_order.auto_order_oid, auto_order, expand=expand)
+    put_item = _find_item(put_response.auto_order, ITEM_ID)
+    print(f"PUT response next_shipment_dts: "
+          f"{put_item.next_shipment_dts if put_item else '(item not in response)'}")
+
+    # 5. Re-GET and verify the change actually persisted. UltraCart can echo a
+    #    value back in the PUT response without it sticking for items in
+    #    unusual states. A fresh GET is the only way to know for sure.
+    verify_response = auto_order_api.get_auto_order_by_reference_order_id(
+        REFERENCE_ORDER_ID, expand=expand)
+    verify_item = _find_item(verify_response.auto_order, ITEM_ID)
+    verified_dts_str = verify_item.next_shipment_dts if verify_item else None
+
+    if verified_dts_str and datetime.fromisoformat(verified_dts_str) == new_shipment_dts:
+        print(f"VERIFIED: next_shipment_dts persisted as {verified_dts_str}")
+        return
+
+    print(f"WARNING: Re-GET shows next_shipment_dts = {verified_dts_str}, "
+          f"expected {new_shipment_iso}.")
+    print("The PUT was accepted by UltraCart but the value did not stick on re-read.")
+    print("This commonly indicates the item is in a state UltraCart manages "
+          "automatically (e.g. mid free-trial). Escalate for human review.")
+
+
+def _find_item(auto_order, item_id):
+    """Return the item whose original_item_id matches, or None."""
+    if auto_order is None:
+        return None
+    for item in auto_order.items or []:
+        if item.original_item_id == item_id:
+            return item
+    return None
+
+
+def _isofmt(dt):
+    """Format a datetime as UltraCart-style ISO 8601 with milliseconds."""
+    return dt.astimezone().isoformat("T", "milliseconds")
+
+
+if __name__ == "__main__":
+    delay_auto_order_item()

--- a/ruby/auto_order/delay_auto_order_item.rb
+++ b/ruby/auto_order/delay_auto_order_item.rb
@@ -1,0 +1,140 @@
+# Fetch with expansion, mutate, persist. UltraCart does not support PATCH.
+#
+# Delay one item's next shipment in an auto-order by N days.
+#
+# This is the canonical pattern for editing an auto-order item in UltraCart:
+#
+#   1. GET the auto-order with the `items` expansion.
+#   2. Mutate the target item IN PLACE on the object returned by GET.
+#   3. PUT the full auto-order back.
+#   4. Re-GET and verify the change actually persisted.
+#
+# UltraCart does NOT support PATCH on auto-orders. Sending a stripped-down item
+# object on PUT is unsafe -- fields you omit (frequency, paused, arbitrary_*,
+# options, etc.) can be lost, and updates to items in unusual states (e.g.
+# mid free-trial) may silently no-op. Always echo the full item objects as
+# returned by GET, then mutate only the field(s) you intend to change.
+#
+# Typical use case: a support bot or AI agent processing
+#     "please delay my next shipment by 30 days"
+# for a specific item in a multi-item auto-order.
+
+require 'date'
+require 'ultracart_api'
+require_relative '../constants'
+
+# Sample values. In a real integration these would come from the customer
+# support request or AI agent context.
+REFERENCE_ORDER_ID = 'DEMO-0009103116' # UltraCart order id that placed the auto-order
+ITEM_ID            = 'ITEM001'         # the original_item_id you want to delay
+DELAY_DAYS         = 30
+
+# DO_WORK defaults to false (dry run). Flip to true to actually persist.
+DO_WORK = false
+
+# How many days before the new shipment date to set the preshipment notice.
+PRESHIPMENT_NOTICE_LEAD_DAYS = 3
+
+def isofmt(dt)
+  dt.new_offset(DateTime.now.offset).strftime('%Y-%m-%dT%H:%M:%S.%L%:z')
+end
+
+def find_item(auto_order, item_id)
+  (auto_order.items || []).find { |i| i.original_item_id == item_id }
+end
+
+auto_order_api = UltracartClient::AutoOrderApi.new_using_api_key(Constants::API_KEY)
+
+# 1. Fetch the full auto-order with items expansion. We need every field on
+#    every item so we can PUT them back unchanged.
+#
+#    Alternative lookup: if you have the auto_order_code instead of the
+#    reference order id, use:
+#        auto_order_api.get_auto_order_by_code(auto_order_code, { :'_expand' => expand })
+expand = 'items'
+response = auto_order_api.get_auto_order_by_reference_order_id(
+  REFERENCE_ORDER_ID, { :'_expand' => expand })
+auto_order = response.auto_order
+if auto_order.nil?
+  warn "ERROR: No auto-order found for reference order #{REFERENCE_ORDER_ID}."
+  exit 1
+end
+
+target = find_item(auto_order, ITEM_ID)
+if target.nil?
+  warn "ERROR: Item #{ITEM_ID} not found in auto-order for #{REFERENCE_ORDER_ID}."
+  exit 1
+end
+
+current_dts_str = target.next_shipment_dts
+if current_dts_str.nil? || current_dts_str.empty?
+  warn "ERROR: Item #{ITEM_ID} has no next_shipment_dts; nothing to delay."
+  exit 1
+end
+
+current_dts = DateTime.iso8601(current_dts_str)
+now = DateTime.now.new_offset(current_dts.offset)
+
+# 2. Compute the new dates. If the stored next_shipment_dts is in the past
+#    (which can happen for items mid-cycle or post-trial), anchoring the
+#    delay to that stale date would leave the customer with a near-term
+#    shipment, not the delay they asked for. Anchor to whichever is later:
+#    the stored date, or now.
+anchor = [current_dts, now].max
+new_shipment_dts = anchor + DELAY_DAYS
+new_notice_dts = new_shipment_dts - PRESHIPMENT_NOTICE_LEAD_DAYS
+
+if new_notice_dts <= now
+  warn "ERROR: Computed preshipment notice #{isofmt(new_notice_dts)} is not in the future."
+  exit 1
+end
+
+# 3. Mutate the target item IN PLACE. Do not rebuild the items array.
+#    Every other field on the item (and every other item in the auto-order)
+#    is preserved exactly as UltraCart returned it.
+new_shipment_iso = isofmt(new_shipment_dts)
+new_notice_iso = isofmt(new_notice_dts)
+target.next_shipment_dts = new_shipment_iso
+target.next_preshipment_notice_dts = new_notice_iso
+
+puts '-' * 60
+puts "Reference order:      #{REFERENCE_ORDER_ID}"
+puts "Item:                 #{ITEM_ID}"
+puts "Current next ship:    #{current_dts_str}"
+puts "Proposed next ship:   #{new_shipment_iso}"
+puts "Proposed notice:      #{new_notice_iso}"
+puts 'Note: stored next_shipment_dts was in the past; anchored delay to today.' if current_dts < now
+puts '-' * 60
+
+unless DO_WORK
+  puts 'DRY RUN -- no changes persisted. Set DO_WORK = true to apply.'
+  exit 0
+end
+
+# 4. PUT the full auto-order back. Note the Ruby SDK's update_auto_order
+#    parameter order: (body, oid, opts) -- body first, then the oid.
+put_response = auto_order_api.update_auto_order(
+  auto_order, auto_order.auto_order_oid, { :'_expand' => expand }
+)
+put_item = find_item(put_response.auto_order, ITEM_ID)
+puts "PUT response next_shipment_dts: #{put_item ? put_item.next_shipment_dts : '(item not in response)'}"
+
+# 5. Re-GET and verify the change actually persisted. UltraCart can echo a
+#    value back in the PUT response without it sticking for items in
+#    unusual states. A fresh GET is the only way to know for sure.
+verify_response = auto_order_api.get_auto_order_by_reference_order_id(
+  REFERENCE_ORDER_ID, { :'_expand' => expand })
+verify_item = find_item(verify_response.auto_order, ITEM_ID)
+verified_dts_str = verify_item ? verify_item.next_shipment_dts : nil
+
+if verified_dts_str && DateTime.iso8601(verified_dts_str) == new_shipment_dts
+  puts "VERIFIED: next_shipment_dts persisted as #{verified_dts_str}"
+  exit 0
+end
+
+puts "WARNING: Re-GET shows next_shipment_dts = #{verified_dts_str.inspect}, " \
+     "expected #{new_shipment_iso}."
+puts 'The PUT was accepted by UltraCart but the value did not stick on re-read.'
+puts 'This commonly indicates the item is in a state UltraCart manages ' \
+     'automatically (e.g. mid free-trial). Escalate for human review.'
+exit 2

--- a/typescript/auto_order/DelayAutoOrderItem.ts
+++ b/typescript/auto_order/DelayAutoOrderItem.ts
@@ -1,0 +1,203 @@
+import { autoOrderApi } from '../api';
+import {
+    AutoOrder,
+    AutoOrderItem,
+} from 'ultracart_rest_api_v2_typescript';
+
+/**
+ * DelayAutoOrderItem
+ *
+ * Delay one item's next shipment in an auto-order by N days.
+ *
+ * Fetch with expansion, mutate, persist. UltraCart does not support PATCH.
+ *
+ * This is the canonical pattern for editing an auto-order item in UltraCart:
+ *
+ *   1. GET the auto-order with the `items` expansion.
+ *   2. Mutate the target item IN PLACE on the object returned by GET.
+ *   3. PUT the full auto-order back.
+ *   4. Re-GET and verify the change actually persisted.
+ *
+ * UltraCart does NOT support PATCH on auto-orders. Sending a stripped-down
+ * item object on PUT is unsafe -- fields you omit (frequency, paused,
+ * arbitrary_*, options, etc.) can be lost, and updates to items in unusual
+ * states (e.g. mid free-trial) may silently no-op. Always echo the full
+ * item objects as returned by GET, then mutate only the field(s) you intend
+ * to change.
+ *
+ * Typical use case: a support bot or AI agent processing
+ *     "please delay my next shipment by 30 days"
+ * for a specific item in a multi-item auto-order.
+ */
+export class DelayAutoOrderItem {
+    // Sample values. In a real integration these would come from the customer
+    // support request or AI agent context.
+    private static readonly REFERENCE_ORDER_ID = 'DEMO-0009103116'; // UltraCart order id that placed the auto-order
+    private static readonly ITEM_ID            = 'ITEM001';         // the original_item_id you want to delay
+    private static readonly DELAY_DAYS         = 30;
+
+    // DO_WORK defaults to false (dry run). Flip to true to actually persist.
+    private static readonly DO_WORK = false;
+
+    // How many days before the new shipment date to set the preshipment notice.
+    private static readonly PRESHIPMENT_NOTICE_LEAD_DAYS = 3;
+    private static readonly MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+    public static async execute(): Promise<void> {
+        console.log(`--- ${this.name} ---`);
+
+        const expand = 'items';
+
+        try {
+            // 1. Fetch the full auto-order with items expansion. We need every field on
+            //    every item so we can PUT them back unchanged.
+            //
+            //    Alternative lookup: if you have the auto_order_code instead of the
+            //    reference order id, use autoOrderApi.getAutoOrderByCode({autoOrderCode, expand}).
+            const getResponse = await autoOrderApi.getAutoOrderByReferenceOrderId({
+                referenceOrderId: this.REFERENCE_ORDER_ID,
+                expand,
+            });
+            const autoOrder = getResponse.auto_order as AutoOrder | undefined;
+            if (!autoOrder) {
+                console.error(`ERROR: No auto-order found for reference order ${this.REFERENCE_ORDER_ID}.`);
+                return;
+            }
+
+            const target = DelayAutoOrderItem.findItem(autoOrder, this.ITEM_ID);
+            if (!target) {
+                console.error(`ERROR: Item ${this.ITEM_ID} not found in auto-order for ${this.REFERENCE_ORDER_ID}.`);
+                return;
+            }
+
+            const currentDtsStr = target.next_shipment_dts;
+            if (!currentDtsStr) {
+                console.error(`ERROR: Item ${this.ITEM_ID} has no next_shipment_dts; nothing to delay.`);
+                return;
+            }
+
+            const currentDts = new Date(currentDtsStr);
+            if (isNaN(currentDts.getTime())) {
+                console.error(`ERROR: Could not parse next_shipment_dts "${currentDtsStr}".`);
+                return;
+            }
+            const now = new Date();
+
+            // 2. Compute the new dates. If the stored next_shipment_dts is in the past
+            //    (which can happen for items mid-cycle or post-trial), anchoring the
+            //    delay to that stale date would leave the customer with a near-term
+            //    shipment, not the delay they asked for. Anchor to whichever is later:
+            //    the stored date, or now.
+            const anchor = currentDts.getTime() > now.getTime() ? currentDts : now;
+            const newShipmentDts = new Date(anchor.getTime() + this.DELAY_DAYS * this.MS_PER_DAY);
+            const newNoticeDts   = new Date(newShipmentDts.getTime()
+                                            - this.PRESHIPMENT_NOTICE_LEAD_DAYS * this.MS_PER_DAY);
+
+            if (newNoticeDts.getTime() <= now.getTime()) {
+                console.error(`ERROR: Computed preshipment notice ${DelayAutoOrderItem.isoFmt(newNoticeDts)} is not in the future.`);
+                return;
+            }
+
+            // 3. Mutate the target item IN PLACE. Do not rebuild the items array.
+            //    Every other field on the item (and every other item in the auto-order)
+            //    is preserved exactly as UltraCart returned it.
+            const newShipmentIso = DelayAutoOrderItem.isoFmt(newShipmentDts);
+            const newNoticeIso   = DelayAutoOrderItem.isoFmt(newNoticeDts);
+            target.next_shipment_dts          = newShipmentIso;
+            target.next_preshipment_notice_dts = newNoticeIso;
+
+            console.log('-'.repeat(60));
+            console.log(`Reference order:      ${this.REFERENCE_ORDER_ID}`);
+            console.log(`Item:                 ${this.ITEM_ID}`);
+            console.log(`Current next ship:    ${currentDtsStr}`);
+            console.log(`Proposed next ship:   ${newShipmentIso}`);
+            console.log(`Proposed notice:      ${newNoticeIso}`);
+            if (currentDts.getTime() < now.getTime()) {
+                console.log('Note: stored next_shipment_dts was in the past; anchored delay to today.');
+            }
+            console.log('-'.repeat(60));
+
+            if (!this.DO_WORK) {
+                console.log('DRY RUN -- no changes persisted. Set DO_WORK = true to apply.');
+                return;
+            }
+
+            // 4. PUT the full auto-order back.
+            //    "No" for validateOriginalOrder skips re-validation of the original order;
+            //    an item-level date edit doesn't need it.
+            const autoOrderOid = autoOrder.auto_order_oid as number;
+            const putResponse = await autoOrderApi.updateAutoOrder({
+                autoOrderOid,
+                autoOrder,
+                validateOriginalOrder: 'No',
+                expand,
+            });
+            const putItem = DelayAutoOrderItem.findItem(putResponse.auto_order as AutoOrder | undefined, this.ITEM_ID);
+            console.log(`PUT response next_shipment_dts: ${putItem ? putItem.next_shipment_dts : '(item not in response)'}`);
+
+            // 5. Re-GET and verify the change actually persisted. UltraCart can echo a
+            //    value back in the PUT response without it sticking for items in
+            //    unusual states. A fresh GET is the only way to know for sure.
+            const verifyResponse = await autoOrderApi.getAutoOrderByReferenceOrderId({
+                referenceOrderId: this.REFERENCE_ORDER_ID,
+                expand,
+            });
+            const verifyItem = DelayAutoOrderItem.findItem(verifyResponse.auto_order as AutoOrder | undefined, this.ITEM_ID);
+            const verifiedDtsStr = verifyItem ? verifyItem.next_shipment_dts : undefined;
+
+            if (verifiedDtsStr && new Date(verifiedDtsStr).getTime() === newShipmentDts.getTime()) {
+                console.log(`VERIFIED: next_shipment_dts persisted as ${verifiedDtsStr}`);
+                return;
+            }
+
+            console.warn(`WARNING: Re-GET shows next_shipment_dts = ${verifiedDtsStr}, expected ${newShipmentIso}.`);
+            console.warn('The PUT was accepted by UltraCart but the value did not stick on re-read.');
+            console.warn('This commonly indicates the item is in a state UltraCart manages '
+                + 'automatically (e.g. mid free-trial). Escalate for human review.');
+        } catch (ex) {
+            console.error(`Error: ${ex instanceof Error ? ex.message : 'Unknown error'}`);
+            console.error(ex instanceof Error ? ex.stack : ex);
+        }
+    }
+
+    private static findItem(autoOrder: AutoOrder | undefined, itemId: string): AutoOrderItem | undefined {
+        if (!autoOrder) return undefined;
+        for (const item of autoOrder.items || []) {
+            if (item.original_item_id === itemId) {
+                return item;
+            }
+        }
+        return undefined;
+    }
+
+    /**
+     * Format a Date as UltraCart-style ISO 8601 with milliseconds in local time
+     * with a numeric timezone offset (e.g. 2026-06-18T09:15:00.000-04:00).
+     *
+     * Date#toISOString() always emits UTC with 'Z'; the Python reference emits
+     * a local offset, which is what the API returns on GET.
+     */
+    private static isoFmt(dt: Date): string {
+        const pad2 = (n: number) => String(n).padStart(2, '0');
+        const pad3 = (n: number) => String(n).padStart(3, '0');
+
+        const year    = dt.getFullYear();
+        const month   = pad2(dt.getMonth() + 1);
+        const day     = pad2(dt.getDate());
+        const hours   = pad2(dt.getHours());
+        const minutes = pad2(dt.getMinutes());
+        const seconds = pad2(dt.getSeconds());
+        const millis  = pad3(dt.getMilliseconds());
+
+        const offsetMin = -dt.getTimezoneOffset();
+        const sign      = offsetMin >= 0 ? '+' : '-';
+        const offsetAbs = Math.abs(offsetMin);
+        const offH      = pad2(Math.floor(offsetAbs / 60));
+        const offM      = pad2(offsetAbs % 60);
+
+        return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}.${millis}${sign}${offH}:${offM}`;
+    }
+}
+
+// Example of how to call the method
+// DelayAutoOrderItem.execute().catch(console.error);


### PR DESCRIPTION
## Summary

Adds a `delay_auto_order_item` sample to every language directory that demonstrates the canonical pattern for editing one item inside a multi-item auto-order:

1. GET the auto-order with the `items` expansion.
2. Mutate the target item IN PLACE on the object returned by GET.
3. PUT the full auto-order back.
4. Re-GET and verify the change actually persisted.

Motivated by a real merchant support case (ticket 1483830) where an AI-agent integration was sending sparse-PATCH-style PUT bodies and getting silent no-ops on one of two subscription items. The sample makes the right pattern explicit and adds a re-GET verification step that catches the silent no-op case before the customer is impacted.

The sample looks up the auto-order by reference (original) order id, which is what a support bot typically has from the customer email. A comment in each file points at `getAutoOrderByCode` as the alternative for callers that already have the auto_order_code.

## What is in the sample

- Hardcoded constants at the top (`REFERENCE_ORDER_ID`, `ITEM_ID`, `DELAY_DAYS`, `DO_WORK`/`DRY_RUN`), matching the dominant convention in the existing auto_order folders.
- Anchor logic: if the stored `next_shipment_dts` is already in the past, the new date is computed as `max(stored, now) + delay_days`. Without this, a stale stored value would produce a near-term shipment instead of the delay the customer asked for.
- Preshipment notice is set to 3 days before the new shipment date.
- The verify step compares the persisted value to the expected value and prints a `WARNING` plus a clear escalation message if they do not match. The text suggests trial-state items as a likely cause; if that turns out not to be the right characterization once we hear back from the auto-order team, tighten that line.

## Languages

Python, C#, Java, JavaScript, TypeScript, PHP, Ruby, curl.

## Testing

Syntax / build checks run locally:

- Python: `py_compile` clean, module imports OK, SDK method signatures verified against `ultracart` package on disk, model attribute access verified.
- JavaScript: `node --check` clean.
- TypeScript: `tsc --noEmit` exit 0.
- PHP: `php -l` clean.
- Ruby: `ruby -c` clean.
- C#: my file produced zero errors. The full `dotnet build` on `SDKSample.csproj` fails with unrelated errors in other files because NuGet packages are not installed in this checkout. Worth a recheck on a developer machine that has the packages restored.
- Java: not built locally - `mvn compile` fails at dependency resolution (`com.ultracart:rest-sdk:jar:4.1.74` not in Maven central). This is the known Java SDK publishing issue, not a problem with the sample itself. Please eyeball.
- curl: not testable.

## Open question to flag

The warning text in the verify branch (across all 8 files) speculates that trial-state items may silently no-op on date PUTs. That characterization came from the merchant case we are diagnosing but has not been confirmed against the auto-order code. If the auto-order team gives a different explanation, we should refine the wording in a follow-up.