### PR TITLE
Add getAutoOrderCancelReasons sample across 6 languages

### DIFF
--- a/csharp/SDKSample.csproj
+++ b/csharp/SDKSample.csproj
@@ -614,8 +614,8 @@
     <Compile Include="workflow\UpdateWorkflowTask.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="com.ultracart.admin.v2, Version=4.1.88.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\com.ultracart.admin.v2.4.1.88\lib\net48\com.ultracart.admin.v2.dll</HintPath>
+    <Reference Include="com.ultracart.admin.v2, Version=4.1.92.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\com.ultracart.admin.v2.4.1.92\lib\net48\com.ultracart.admin.v2.dll</HintPath>
     </Reference>
     <Reference Include="JsonSubTypes, Version=1.7.0.0, Culture=neutral, PublicKeyToken=ee75fc290dbc1176">
       <HintPath>packages\JsonSubTypes.1.7.0\lib\net40\JsonSubTypes.dll</HintPath>

--- a/csharp/auto_order/GetAutoOrderCancelReasons.cs
+++ b/csharp/auto_order/GetAutoOrderCancelReasons.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Reflection;
+using com.ultracart.admin.v2.Api;
+using com.ultracart.admin.v2.Model;
+
+namespace SdkSample.auto_order
+{
+    public class GetAutoOrderCancelReasons
+    {
+        /*
+         * Retrieves the list of cancel reasons that can be presented to customers when
+         * cancelling an auto order (e.g., in MyAccount). Each reason includes the reason
+         * text, an optional MyAccount alternate description, and whether the reason is
+         * visible in MyAccount.
+         */
+        public static void Execute()
+        {
+            Console.WriteLine("--- " + MethodBase.GetCurrentMethod()?.DeclaringType?.Name + " ---");
+
+            try
+            {
+                AutoOrderApi autoOrderApi = new AutoOrderApi(Constants.ApiKey);
+
+                AutoOrderCancelReasonsResponse response = autoOrderApi.GetAutoOrderCancelReasons();
+
+                foreach (AutoOrderCancelReason cancelReason in response.CancelReasons)
+                {
+                    Console.WriteLine(cancelReason);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Console.WriteLine(ex.StackTrace);
+            }
+        }
+    }
+}

--- a/csharp/packages.config
+++ b/csharp/packages.config
@@ -16,5 +16,5 @@
   <package id="System.Text.Json" version="9.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
-  <package id="com.ultracart.admin.v2" version="4.1.88" targetFramework="net48" />
+  <package id="com.ultracart.admin.v2" version="4.1.92" targetFramework="net48" />
 </packages>

--- a/javascript/auto_order/getAutoOrderCancelReasons.js
+++ b/javascript/auto_order/getAutoOrderCancelReasons.js
@@ -1,0 +1,34 @@
+import { autoOrderApi } from "../api.js";
+
+/**
+ * Retrieves the list of cancel reasons that can be presented to customers when
+ * cancelling an auto order (e.g., in MyAccount). Each reason includes the reason
+ * text, an optional MyAccount alternate description, and whether the reason is
+ * visible in MyAccount.
+ */
+export async function getAutoOrderCancelReasons() {
+  console.log(`--- ${getAutoOrderCancelReasons.name} ---`);
+
+  try {
+    const apiResponse = await new Promise((resolve, reject) => {
+      autoOrderApi.getAutoOrderCancelReasons(function (error, data, response) {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(data, response);
+        }
+      });
+    });
+
+    const cancelReasons = apiResponse.cancel_reasons || [];
+    cancelReasons.forEach((cancelReason) => {
+      console.log(cancelReason);
+    });
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    console.error(error instanceof Error ? error.stack : error);
+  }
+}
+
+// Optional: If you want to call the function
+// getAutoOrderCancelReasons().catch(console.error);

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "luxon": "3.2.1",
         "ssl-root-cas": "^1.2.3",
-        "ultra_cart_rest_api_v2": "^4.1.88"
+        "ultra_cart_rest_api_v2": "^4.1.91"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1252,10 +1252,9 @@
       }
     },
     "node_modules/ultra_cart_rest_api_v2": {
-      "version": "4.1.88",
-      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.88.tgz",
-      "integrity": "sha512-B/hEDuVyfNWnU511f7HyyxIrFBQjn4Y9CMXYkBDC3lZpY/WuQCxWUTBJSDWfLsbPvjGO5ekHfl04Ntwz0Uqm/A==",
-      "license": "Unlicense",
+      "version": "4.1.91",
+      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.91.tgz",
+      "integrity": "sha512-VNKAAKsOHUSLSQvTqVklDUaSdUs4FeNajOqa8u3/7z9xPUHFD2hx2PNfJfyDHUEPgFM1GcbtuPyWXZeVihD9LQ==",
       "dependencies": {
         "@babel/cli": "^7.0.0",
         "superagent": "^5.3.0"
@@ -2202,9 +2201,9 @@
       }
     },
     "ultra_cart_rest_api_v2": {
-      "version": "4.1.88",
-      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.88.tgz",
-      "integrity": "sha512-B/hEDuVyfNWnU511f7HyyxIrFBQjn4Y9CMXYkBDC3lZpY/WuQCxWUTBJSDWfLsbPvjGO5ekHfl04Ntwz0Uqm/A==",
+      "version": "4.1.91",
+      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.91.tgz",
+      "integrity": "sha512-VNKAAKsOHUSLSQvTqVklDUaSdUs4FeNajOqa8u3/7z9xPUHFD2hx2PNfJfyDHUEPgFM1GcbtuPyWXZeVihD9LQ==",
       "requires": {
         "@babel/cli": "^7.0.0",
         "superagent": "^5.3.0"

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "luxon": "3.2.1",
     "ssl-root-cas": "^1.2.3",
-    "ultra_cart_rest_api_v2": "^4.1.88"
+    "ultra_cart_rest_api_v2": "^4.1.91"
   }
 }

--- a/php/auto_order/getAutoOrderCancelReasons.php
+++ b/php/auto_order/getAutoOrderCancelReasons.php
@@ -1,0 +1,22 @@
+<?php
+
+ini_set('display_errors', 1);
+
+/*
+ * Retrieves the list of cancel reasons that can be presented to customers when
+ * cancelling an auto order (e.g., in MyAccount). Each reason includes the reason
+ * text, an optional MyAccount alternate description, and whether the reason is
+ * visible in MyAccount.
+ */
+
+require_once '../vendor/autoload.php';
+require_once '../samples.php';
+
+
+$auto_order_api = Samples::getAutoOrderApi();
+
+$api_response = $auto_order_api->getAutoOrderCancelReasons();
+
+foreach ($api_response->getCancelReasons() as $cancel_reason) {
+    var_dump($cancel_reason);
+}

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "ultracart/rest_api_v2_sdk_php": "4.1.88"
+    "ultracart/rest_api_v2_sdk_php": "4.1.92"
   },
   "config": {
     "discard-changes" : true

--- a/python/auto_order/get_auto_order_cancel_reasons.py
+++ b/python/auto_order/get_auto_order_cancel_reasons.py
@@ -1,0 +1,20 @@
+from ultracart.apis import AutoOrderApi
+from samples import api_client
+
+
+# Retrieves the list of cancel reasons that can be presented to customers when
+# cancelling an auto order (e.g., in MyAccount). Each reason includes the reason
+# text, an optional MyAccount alternate description, and whether the reason is
+# visible in MyAccount.
+
+def get_auto_order_cancel_reasons():
+    auto_order_api = AutoOrderApi(api_client())
+
+    api_response = auto_order_api.get_auto_order_cancel_reasons()
+
+    for cancel_reason in api_response.cancel_reasons:
+        print(cancel_reason)
+
+
+if __name__ == "__main__":
+    get_auto_order_cancel_reasons()

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,1 @@
+ultracart-rest-sdk==4.1.92

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'rubocop', group: 'development'
-gem 'ultracart_api', '4.1.88'
+gem 'ultracart_api', '4.1.92'

--- a/ruby/auto_order/get_auto_order_cancel_reasons.rb
+++ b/ruby/auto_order/get_auto_order_cancel_reasons.rb
@@ -1,0 +1,15 @@
+require 'ultracart_api'
+require_relative '../constants'
+
+# Retrieves the list of cancel reasons that can be presented to customers when
+# cancelling an auto order (e.g., in MyAccount). Each reason includes the reason
+# text, an optional MyAccount alternate description, and whether the reason is
+# visible in MyAccount.
+
+auto_order_api = UltracartClient::AutoOrderApi.new_using_api_key(Constants::API_KEY)
+
+api_response = auto_order_api.get_auto_order_cancel_reasons
+
+api_response.cancel_reasons.each do |cancel_reason|
+  puts cancel_reason.inspect
+end

--- a/typescript/auto_order/GetAutoOrderCancelReasons.ts
+++ b/typescript/auto_order/GetAutoOrderCancelReasons.ts
@@ -1,0 +1,27 @@
+import { autoOrderApi } from "../api";
+import { AutoOrderCancelReason } from 'ultracart_rest_api_v2_typescript';
+
+/**
+ * Retrieves the list of cancel reasons that can be presented to customers when
+ * cancelling an auto order (e.g., in MyAccount). Each reason includes the reason
+ * text, an optional MyAccount alternate description, and whether the reason is
+ * visible in MyAccount.
+ */
+export async function getAutoOrderCancelReasons(): Promise<void> {
+  console.log(`--- ${getAutoOrderCancelReasons.name} ---`);
+
+  try {
+    const apiResponse = await autoOrderApi.getAutoOrderCancelReasons();
+
+    const cancelReasons: AutoOrderCancelReason[] = apiResponse.cancel_reasons || [];
+    cancelReasons.forEach((cancelReason) => {
+      console.log(cancelReason);
+    });
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    console.error(error instanceof Error ? error.stack : error);
+  }
+}
+
+// Optional: If you want to call the function
+// getAutoOrderCancelReasons().catch(console.error);

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -7,7 +7,7 @@
     "@types/node": "^16.18.126",
     "luxon": "2.5.2",
     "typescript": "^4.9.5",
-    "ultracart_rest_api_v2_typescript": "4.1.88",
+    "ultracart_rest_api_v2_typescript": "4.1.91",
     "uuid": "^11.1.0"
   },
   "author": "UltraCart",


### PR DESCRIPTION
## Summary
- Adds `AutoOrderApi.getAutoOrderCancelReasons` samples for C#, JavaScript, TypeScript, PHP, Ruby, and Python.
- Bumps each language's UltraCart SDK dependency to the latest published version (C# 4.1.92, JS/TS 4.1.91, PHP 4.1.92, Ruby 4.1.92) and adds `python/requirements.txt` pinning `ultracart-rest-sdk==4.1.92`.
- Java sample is intentionally left blank: `com.ultracart:rest-sdk` on Maven Central is still at 4.1.13 and cannot resolve the version pinned in `pom.xml`. See `SDK_PUBLISHING_ISSUES.md`.

## Test plan
- [ ] C#: `nuget restore` succeeds; sample compiles and runs against a sandbox API key.
- [ ] JavaScript: `npm install` clean; run `node auto_order/getAutoOrderCancelReasons.js`.
- [ ] TypeScript: `npm install` clean; `ts-node` the sample.
- [ ] PHP: `composer install` clean; `php auto_order/getAutoOrderCancelReasons.php`.
- [ ] Ruby: `bundle install` clean; `ruby auto_order/get_auto_order_cancel_reasons.rb`.
- [ ] Python: `pip install -r requirements.txt`; `python auto_order/get_auto_order_cancel_reasons.py`.
- [ ] Verify each prints the list of `cancel_reasons` with `reason`, `myaccount_alternate_description`, and `visible_in_myaccount` fields.

Generated with [Claude Code](https://claude.com/claude-code)