### PR TITLE
Add Bulk Jobs API samples across 8 languages (SDK 4.1.109)

### DIFF
--- a/csharp/SDKSample.csproj
+++ b/csharp/SDKSample.csproj
@@ -36,6 +36,8 @@
   <ItemGroup>
     <Compile Include="affiliate\GetClicksByQuery.cs" />
     <Compile Include="affiliate\GetLedgersByQuery.cs" />
+    <Compile Include="bulk\BulkImportOrders.cs" />
+    <Compile Include="bulk\BulkUpsertCustomers.cs" />
     <Compile Include="fraud\Introduction.cs" />
     <Compile Include="fraud\GetFraudLookupValues.cs" />
     <Compile Include="fraud\SearchFraudRules.cs" />
@@ -621,8 +623,8 @@
     <Compile Include="workflow\UpdateWorkflowTask.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="com.ultracart.admin.v2, Version=4.1.92.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\com.ultracart.admin.v2.4.1.92\lib\net48\com.ultracart.admin.v2.dll</HintPath>
+    <Reference Include="com.ultracart.admin.v2, Version=4.1.109.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\com.ultracart.admin.v2.4.1.109\lib\net48\com.ultracart.admin.v2.dll</HintPath>
     </Reference>
     <Reference Include="JsonSubTypes, Version=1.7.0.0, Culture=neutral, PublicKeyToken=ee75fc290dbc1176">
       <HintPath>packages\JsonSubTypes.1.7.0\lib\net40\JsonSubTypes.dll</HintPath>

--- a/csharp/Samples.cs
+++ b/csharp/Samples.cs
@@ -5,6 +5,11 @@ namespace SdkSample
 {
     public class Samples
     {
+        public static BulkApi GetBulkApi()
+        {
+            return new BulkApi(Constants.ApiKey);
+        }
+
         public static GiftCertificateApi GetGiftCertificateApi()
         {
             return new GiftCertificateApi(Constants.ApiKey);

--- a/csharp/bulk/BulkImportOrders.cs
+++ b/csharp/bulk/BulkImportOrders.cs
@@ -1,0 +1,203 @@
+// Bulk import orders — end-to-end lifecycle.
+//
+// The bulk API is a throughput multiplier for the per-record REST endpoints: you
+// upload an NDJSON file of records, submit one job, then poll it to completion.
+//
+// Flow demonstrated here:
+//   1. Build an NDJSON payload (one order per line, each with a stable _merchant_record_id).
+//   2. Ask the Bulk API for a presigned S3 upload URL.
+//   3. PUT the NDJSON bytes straight to that URL (this step does NOT go through the SDK).
+//   4. Submit the job. Orders are insert-only; operation defaults to "insert".
+//   5. Poll the job until it reaches a terminal status.
+//   6. Print the counts and list any failed records.
+//
+// For create-or-update semantics, see BulkUpsertCustomers.cs (customer upsert).
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using com.ultracart.admin.v2.Api;
+using com.ultracart.admin.v2.Client;
+using com.ultracart.admin.v2.Model;
+using Newtonsoft.Json;
+
+namespace SdkSample.bulk
+{
+    // ReSharper disable once ClassNeverInstantiated.Global
+    public class BulkImportOrders
+    {
+        private const string ObjectType = "order";
+
+        // Terminal job statuses — poll until the job reports one of these. Status is a
+        // generated enum on the SDK model (Partialsuccess == the wire's "partial_success").
+        private static readonly BulkJob.StatusEnum[] TerminalStatuses =
+        {
+            BulkJob.StatusEnum.Succeeded,
+            BulkJob.StatusEnum.Partialsuccess,
+            BulkJob.StatusEnum.Failed,
+            BulkJob.StatusEnum.Cancelled
+        };
+
+        // The S3 upload is a raw HTTP PUT, so it does not go through the SDK.
+        private static readonly HttpClient HttpClient = new HttpClient();
+
+        public static void Execute()
+        {
+            try
+            {
+                RunBulkImport();
+            }
+            catch (ApiException e)
+            {
+                Console.WriteLine("An ApiException occurred.  Please review the following error:");
+                Console.WriteLine(e); // <-- change_me: handle gracefully
+                Environment.Exit(1);
+            }
+        }
+
+        private static void RunBulkImport()
+        {
+            BulkApi bulkApi = Samples.GetBulkApi();
+
+            // --- 1. Build the NDJSON payload -----------------------------------------
+            // Each line is exactly what POST /rest/v2/order accepts, PLUS a top-level
+            // _merchant_record_id — the bulk-surface dedupe key. Use a STABLE value derived
+            // from your source system (e.g. the legacy order id), NOT a fresh UUID, so that
+            // re-running a fixed file collapses to the original landing instead of re-inserting.
+            //
+            // Build the lines as plain objects (anonymous types here), NOT SDK models: the
+            // _merchant_record_id marker is a bulk-surface field, not part of the order model.
+            var orders = new List<object>
+            {
+                new
+                {
+                    _merchant_record_id = "legacy-order-1029384",
+                    merchant_order_id = "ORD-1029384",
+                    creation_dts = "2023-11-14T09:22:00Z",
+                    currency_code = "USD",
+                    total = 79.50,
+                    customer_profile = new { email = "jane@example.com" },
+                    items = new[]
+                    {
+                        new { merchant_item_id = "WIDGET-RED", quantity = 2, unit_cost = new { currency_code = "USD", value = 35.00 } }
+                    },
+                    shipping = new
+                    {
+                        ship_to = new
+                        {
+                            first_name = "Jane", last_name = "Doe", address1 = "123 Main St",
+                            city = "Austin", state_region = "TX", postal_code = "78701", country_code = "US"
+                        },
+                        shipping_method = "Standard"
+                    }
+                },
+                new
+                {
+                    _merchant_record_id = "legacy-order-1029385",
+                    merchant_order_id = "ORD-1029385",
+                    creation_dts = "2023-11-15T14:03:00Z",
+                    currency_code = "USD",
+                    total = 35.00,
+                    customer_profile = new { email = "john@example.com" },
+                    items = new[]
+                    {
+                        new { merchant_item_id = "WIDGET-BLUE", quantity = 1, unit_cost = new { currency_code = "USD", value = 35.00 } }
+                    }
+                }
+            };
+
+            // NDJSON = one minified JSON object per line, LF-separated. Do NOT wrap the records
+            // in a JSON array and do NOT pretty-print — the worker parses the file line by line.
+            var lines = new List<string>();
+            foreach (var order in orders)
+            {
+                lines.Add(JsonConvert.SerializeObject(order));
+            }
+            string ndjson = string.Join("\n", lines);
+            byte[] payloadBytes = Encoding.UTF8.GetBytes(ndjson);
+
+            // --- 2. Get a presigned upload URL ---------------------------------------
+            BulkUploadUrlResponse uploadUrlResponse = bulkApi.BulkGenerateUploadUrl(ObjectType);
+            string uploadUrl = uploadUrlResponse.UploadUrl;
+            string s3Key = uploadUrlResponse.S3Key;
+            Console.WriteLine($"Upload URL issued (s3_key={s3Key}, max_records={uploadUrlResponse.MaxRecords}).");
+
+            // --- 3. Upload the NDJSON straight to the presigned URL ------------------
+            // A plain HTTP PUT to S3, using the framework HttpClient rather than the SDK.
+            var content = new ByteArrayContent(payloadBytes);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/x-ndjson");
+            HttpResponseMessage putResponse = HttpClient.PutAsync(uploadUrl, content).GetAwaiter().GetResult();
+            if (!putResponse.IsSuccessStatusCode)
+            {
+                throw new Exception($"Upload PUT failed: {(int)putResponse.StatusCode} {putResponse.ReasonPhrase}");
+            }
+            Console.WriteLine($"Uploaded {orders.Count} records ({payloadBytes.Length} bytes).");
+
+            // --- 4. Submit the job --------------------------------------------------
+            var request = new BulkJobRequest
+            {
+                S3Key = s3Key,
+                Operation = BulkJobRequest.OperationEnum.Insert // default for orders; shown here for clarity
+                // WebhookUrl = "https://example.com/hooks/bulk" // optional one-shot completion POST
+            };
+
+            BulkJobResponse submitResponse = bulkApi.BulkSubmitJob(ObjectType, request);
+            BulkJob job = submitResponse.BulkJob;
+            string jobId = job.JobId;
+            Console.WriteLine($"Submitted job {jobId} (status={job.Status}).");
+
+            // --- 5. Poll until terminal (bounded so it can't hang) ------------------
+            job = PollUntilTerminal(bulkApi, jobId, job);
+
+            // --- 6. Report ----------------------------------------------------------
+            Console.WriteLine($"\nJob {jobId} finished: {job.Status}");
+            Console.WriteLine($"  success={job.SuccessCount} failed={job.FailCount} duplicate={job.DuplicateCount}");
+
+            if (job.FailCount > 0)
+            {
+                Console.WriteLine("\nFailed records:");
+                string cursor = null;
+                do
+                {
+                    BulkRecordsResponse recordsResponse = bulkApi.BulkGetJobRecords(ObjectType, jobId, "failed", cursor, 100);
+                    foreach (BulkRecord record in recordsResponse.Records)
+                    {
+                        Console.WriteLine($"  line {record.LineNumber} [{record.MerchantRecordId}] {record.ErrorCode}: {record.ErrorMessage}");
+                    }
+                    cursor = recordsResponse.NextCursor;
+                } while (!string.IsNullOrEmpty(cursor));
+            }
+        }
+
+        // Poll the job until it reaches a terminal status. Bulk endpoints sit behind their own
+        // rate-limit bucket, so polling does not consume your normal REST budget — but still poll
+        // politely, and bound the loop (~20 tries) so a stuck job can't hang the sample.
+        private static BulkJob PollUntilTerminal(BulkApi bulkApi, string jobId, BulkJob job)
+        {
+            const int maxTries = 20;
+            for (int i = 0; i < maxTries && !IsTerminal(job.Status); i++)
+            {
+                Thread.Sleep(3000);
+                job = bulkApi.BulkGetJob(ObjectType, jobId).BulkJob;
+                Console.WriteLine($"  status={job.Status} processed={job.ProcessedRecords}/{job.TotalRecords}");
+            }
+            return job;
+        }
+
+        private static bool IsTerminal(BulkJob.StatusEnum? status)
+        {
+            return status.HasValue && Array.IndexOf(TerminalStatuses, status.Value) >= 0;
+        }
+
+        // C# projects allow a single Main entry point, which already lives in EntryPoint.cs.
+        // To run just this sample standalone, comment out EntryPoint.Main and uncomment:
+        //
+        // public static void Main(string[] args)
+        // {
+        //     Execute();
+        // }
+    }
+}

--- a/csharp/bulk/BulkUpsertCustomers.cs
+++ b/csharp/bulk/BulkUpsertCustomers.cs
@@ -1,0 +1,192 @@
+// Bulk upsert customers — end-to-end lifecycle with operation="upsert".
+//
+// "upsert" creates a customer when none is found and otherwise replaces the
+// existing one (a full-record replace, identical to PUT /rest/v2/customer — a
+// field you omit is cleared, it is not a partial merge). Upsert is customer-only
+// in v1; submitting operation="upsert" to /rest/v2/bulk/order is a 400.
+//
+// Identity resolution per line:
+//   1. The _merchant_record_id marker from a prior landing wins (that customer is updated).
+//   2. No marker -> resolve by the line's email; still no match -> insert.
+// On success each record reports action="inserted" or action="updated".
+//
+// See BulkImportOrders.cs for the fully-commented base flow; this sample highlights
+// only what differs for upsert.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using com.ultracart.admin.v2.Api;
+using com.ultracart.admin.v2.Client;
+using com.ultracart.admin.v2.Model;
+using Newtonsoft.Json;
+
+namespace SdkSample.bulk
+{
+    // ReSharper disable once ClassNeverInstantiated.Global
+    public class BulkUpsertCustomers
+    {
+        private const string ObjectType = "customer";
+
+        // Status is a generated enum on the SDK model (Partialsuccess == wire "partial_success").
+        private static readonly BulkJob.StatusEnum[] TerminalStatuses =
+        {
+            BulkJob.StatusEnum.Succeeded,
+            BulkJob.StatusEnum.Partialsuccess,
+            BulkJob.StatusEnum.Failed,
+            BulkJob.StatusEnum.Cancelled
+        };
+
+        // The S3 upload is a raw HTTP PUT, so it does not go through the SDK.
+        private static readonly HttpClient HttpClient = new HttpClient();
+
+        public static void Execute()
+        {
+            try
+            {
+                RunBulkUpsert();
+            }
+            catch (ApiException e)
+            {
+                Console.WriteLine("An ApiException occurred.  Please review the following error:");
+                Console.WriteLine(e); // <-- change_me: handle gracefully
+                Environment.Exit(1);
+            }
+        }
+
+        private static void RunBulkUpsert()
+        {
+            BulkApi bulkApi = Samples.GetBulkApi();
+
+            // Each line is what the per-record customer-create endpoint accepts, plus the
+            // top-level _merchant_record_id. When email is your natural key, using it as the
+            // _merchant_record_id makes the bulk dedupe and UC's email-uniqueness agree.
+            // Build the lines as plain objects (anonymous types), NOT SDK models.
+            var customers = new List<object>
+            {
+                new
+                {
+                    _merchant_record_id = "jane@example.com",
+                    email = "jane@example.com",
+                    first_name = "Jane",
+                    last_name = "Doe",
+                    billing = new[]
+                    {
+                        new
+                        {
+                            first_name = "Jane", last_name = "Doe", address1 = "123 Main St",
+                            city = "Austin", state_region = "TX", postal_code = "78701",
+                            country_code = "US", default_billing = true
+                        }
+                    },
+                    tags = new[] { "legacy-import" }
+                },
+                new
+                {
+                    _merchant_record_id = "john@example.com",
+                    email = "john@example.com",
+                    first_name = "John",
+                    last_name = "Smith"
+                }
+            };
+
+            var lines = new List<string>();
+            foreach (var customer in customers)
+            {
+                lines.Add(JsonConvert.SerializeObject(customer));
+            }
+            string ndjson = string.Join("\n", lines);
+            byte[] payloadBytes = Encoding.UTF8.GetBytes(ndjson);
+
+            BulkUploadUrlResponse uploadUrlResponse = bulkApi.BulkGenerateUploadUrl(ObjectType);
+            string uploadUrl = uploadUrlResponse.UploadUrl;
+            string s3Key = uploadUrlResponse.S3Key;
+            Console.WriteLine($"Upload URL issued (s3_key={s3Key}).");
+
+            var content = new ByteArrayContent(payloadBytes);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/x-ndjson");
+            HttpResponseMessage putResponse = HttpClient.PutAsync(uploadUrl, content).GetAwaiter().GetResult();
+            if (!putResponse.IsSuccessStatusCode)
+            {
+                throw new Exception($"Upload PUT failed: {(int)putResponse.StatusCode} {putResponse.ReasonPhrase}");
+            }
+            Console.WriteLine($"Uploaded {customers.Count} customers.");
+
+            // The only submit difference vs. insert: operation = "upsert".
+            var request = new BulkJobRequest
+            {
+                S3Key = s3Key,
+                Operation = BulkJobRequest.OperationEnum.Upsert
+            };
+
+            BulkJobResponse submitResponse = bulkApi.BulkSubmitJob(ObjectType, request);
+            BulkJob job = submitResponse.BulkJob;
+            string jobId = job.JobId;
+            Console.WriteLine($"Submitted upsert job {jobId} (operation={job.Operation}).");
+
+            job = PollUntilTerminal(bulkApi, jobId, job);
+
+            Console.WriteLine($"\nJob {jobId} finished: {job.Status}");
+            Console.WriteLine($"  success={job.SuccessCount} failed={job.FailCount} duplicate={job.DuplicateCount}");
+
+            // On upsert, each successful record tells you whether it created or replaced a
+            // customer via the "action" field (inserted | updated).
+            Console.WriteLine("\nPer-record actions:");
+            string cursor = null;
+            do
+            {
+                BulkRecordsResponse recordsResponse = bulkApi.BulkGetJobRecords(ObjectType, jobId, "success", cursor, 100);
+                foreach (BulkRecord record in recordsResponse.Records)
+                {
+                    Console.WriteLine($"  [{record.MerchantRecordId}] {record.Action} -> uc_id={record.UcId}");
+                }
+                cursor = recordsResponse.NextCursor;
+            } while (!string.IsNullOrEmpty(cursor));
+
+            if (job.FailCount > 0)
+            {
+                Console.WriteLine("\nFailed records (an email_conflict means the line's email belongs to a different customer than the marker resolved to):");
+                cursor = null;
+                do
+                {
+                    BulkRecordsResponse recordsResponse = bulkApi.BulkGetJobRecords(ObjectType, jobId, "failed", cursor, 100);
+                    foreach (BulkRecord record in recordsResponse.Records)
+                    {
+                        Console.WriteLine($"  line {record.LineNumber} [{record.MerchantRecordId}] {record.ErrorCode}: {record.ErrorMessage}");
+                    }
+                    cursor = recordsResponse.NextCursor;
+                } while (!string.IsNullOrEmpty(cursor));
+            }
+        }
+
+        // Poll the job until it reaches a terminal status, bounded (~20 tries) so a stuck job
+        // can't hang the sample. Bulk polling uses its own rate-limit bucket.
+        private static BulkJob PollUntilTerminal(BulkApi bulkApi, string jobId, BulkJob job)
+        {
+            const int maxTries = 20;
+            for (int i = 0; i < maxTries && !IsTerminal(job.Status); i++)
+            {
+                Thread.Sleep(3000);
+                job = bulkApi.BulkGetJob(ObjectType, jobId).BulkJob;
+                Console.WriteLine($"  status={job.Status} processed={job.ProcessedRecords}/{job.TotalRecords}");
+            }
+            return job;
+        }
+
+        private static bool IsTerminal(BulkJob.StatusEnum? status)
+        {
+            return status.HasValue && Array.IndexOf(TerminalStatuses, status.Value) >= 0;
+        }
+
+        // C# projects allow a single Main entry point, which already lives in EntryPoint.cs.
+        // To run just this sample standalone, comment out EntryPoint.Main and uncomment:
+        //
+        // public static void Main(string[] args)
+        // {
+        //     Execute();
+        // }
+    }
+}

--- a/csharp/packages.config
+++ b/csharp/packages.config
@@ -16,5 +16,5 @@
   <package id="System.Text.Json" version="9.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
-  <package id="com.ultracart.admin.v2" version="4.1.97" targetFramework="net48" />
+  <package id="com.ultracart.admin.v2" version="4.1.109" targetFramework="net48" />
 </packages>

--- a/curl/bulk/bulkImportOrders.curl
+++ b/curl/bulk/bulkImportOrders.curl
@@ -1,0 +1,233 @@
+The bulk API is a throughput multiplier for the per-record REST endpoints: you
+upload an NDJSON file of records, submit one job, then poll it to completion.
+This sample imports **orders** (insert-only) end-to-end with plain curl. For
+create-or-update semantics see bulkUpsertCustomers.curl.
+
+Flow:
+1. Build an NDJSON payload (one order per line, each with a stable `_merchant_record_id`).
+2. Ask the Bulk API for a presigned S3 upload URL.
+3. PUT the NDJSON bytes straight to that URL (this step is NOT an UltraCart REST call — no auth header).
+4. Submit the job. Orders are insert-only; operation defaults to `insert`.
+5. Poll the job until it reaches a terminal status (bounded so it can't hang).
+6. Print the counts and list any failed records.
+
+---
+
+**Step 1 — Build the NDJSON payload**
+
+NDJSON = one minified JSON object per line, LF-separated, UTF-8, no BOM. Do NOT
+wrap the records in a JSON array and do NOT pretty-print — the worker parses the
+file line by line, so an array or a multi-line record fails the whole job with
+`payload_unparseable`. Each line is exactly what `POST /rest/v2/order` accepts,
+PLUS a top-level `_merchant_record_id` — the bulk-surface dedupe key. Use a
+STABLE value derived from your source system (e.g. the legacy order id), NOT a
+fresh UUID, so re-running a fixed file collapses to the original landing instead
+of re-inserting.
+
+```bash
+cat > orders.ndjson <<'EOF'
+{"_merchant_record_id":"legacy-order-1029384","merchant_order_id":"ORD-1029384","creation_dts":"2023-11-14T09:22:00Z","currency_code":"USD","total":79.50,"customer_profile":{"email":"jane@example.com"},"items":[{"merchant_item_id":"WIDGET-RED","quantity":2,"unit_cost":{"currency_code":"USD","value":35.00}}],"shipping":{"ship_to":{"first_name":"Jane","last_name":"Doe","address1":"123 Main St","city":"Austin","state_region":"TX","postal_code":"78701","country_code":"US"},"shipping_method":"Standard"}}
+{"_merchant_record_id":"legacy-order-1029385","merchant_order_id":"ORD-1029385","creation_dts":"2023-11-15T14:03:00Z","currency_code":"USD","total":35.00,"customer_profile":{"email":"john@example.com"},"items":[{"merchant_item_id":"WIDGET-BLUE","quantity":1,"unit_cost":{"currency_code":"USD","value":35.00}}]}
+EOF
+```
+
+Minimum viable order line: `_merchant_record_id`, `merchant_order_id`,
+`creation_dts`, `customer_profile.email`, `items[]` (>=1), `total`, `currency_code`.
+
+---
+
+**Step 2 — Request a presigned upload URL**
+
+**Request \[[Create API Key](https://ultracart.atlassian.net/wiki/spaces/ucdoc/pages/38688545/API+Simple+Key)\]**
+```bash
+curl -X POST "https://secure.ultracart.com/rest/v2/bulk/order/upload-url" \
+  -H "Accept: application/json" \
+  -H "X-UltraCart-Api-Version: 2017-03-01" \
+  -H "x-ultracart-simple-key: fbfa455fa3bc2e019e456ffe06200100122d966fc28870019e456ffe08200100"
+```
+
+**Response Headers**
+```html
+Status: 200 OK
+X-UltraCart-Request-Id: 07F7FA848E2892019A0DA4E00380011
+Content-Type: application/json; charset=UTF-8
+Transfer-Encoding: chunked
+Date: Fri, 03 Jul 2026 15:22:00 GMT
+```
+
+**Response Body**
+```json
+{
+    "upload_url": "https://uc-bulk-uploads.s3.amazonaws.com/bulk-jobs/DEMO/9a0da4e0-0380-4f11-8c21-1029384abcd0.ndjson?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=EXAMPLESIGNATURE",
+    "s3_key": "bulk-jobs/DEMO/9a0da4e0-0380-4f11-8c21-1029384abcd0.ndjson",
+    "expires_at": "2026-07-03T15:37:00Z",
+    "max_records": 100000,
+    "success": true,
+    "metadata": {}
+}
+```
+
+---
+
+**Step 3 — Upload the NDJSON straight to the presigned URL**
+
+A plain HTTP PUT to S3 — this does NOT carry your API key and does NOT go through
+the UltraCart REST API. Send the raw bytes with `--data-binary` so curl does not
+strip the newlines. Use the `upload_url` value returned in Step 2 verbatim (its
+signature is bound to the exact path/query).
+
+**Request**
+```bash
+curl -X PUT "https://uc-bulk-uploads.s3.amazonaws.com/bulk-jobs/DEMO/9a0da4e0-0380-4f11-8c21-1029384abcd0.ndjson?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=EXAMPLESIGNATURE" \
+  -H "Content-Type: application/x-ndjson" \
+  --data-binary @orders.ndjson
+```
+
+**Response Headers**
+```html
+Status: 200 OK
+x-amz-request-id: 9A0DA4E00380F11C
+ETag: "3f1c2b9e0a7d4e5f6a8b9c0d1e2f3a4b"
+Content-Length: 0
+Date: Fri, 03 Jul 2026 15:22:01 GMT
+```
+
+S3 returns an empty body on success; any non-2xx means re-request a URL and retry.
+
+---
+
+**Step 4 — Submit the job**
+
+The submit body carries the `s3_key` from Step 2 and the `operation`. Orders are
+insert-only, so `operation` defaults to `insert`; it is shown here for clarity.
+Submitting `operation=upsert` to `/bulk/order` is a 400 (upsert is customer-only).
+
+**Request \[[Create API Key](https://ultracart.atlassian.net/wiki/spaces/ucdoc/pages/38688545/API+Simple+Key)\]**
+```bash
+curl -X POST "https://secure.ultracart.com/rest/v2/bulk/order" \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  -H "X-UltraCart-Api-Version: 2017-03-01" \
+  -H "x-ultracart-simple-key: fbfa455fa3bc2e019e456ffe06200100122d966fc28870019e456ffe08200100" \
+  -d $'{
+    "s3_key": "bulk-jobs/DEMO/9a0da4e0-0380-4f11-8c21-1029384abcd0.ndjson",
+    "operation": "insert"
+}'
+```
+
+**Response Headers**
+```html
+Status: 200 OK
+X-UltraCart-Request-Id: 1B2C3D4E5F60718293A4B5C6D7E8F901
+Content-Type: application/json; charset=UTF-8
+Transfer-Encoding: chunked
+Date: Fri, 03 Jul 2026 15:22:02 GMT
+```
+
+**Response Body**
+```json
+{
+    "bulk_job": {
+        "job_id": "BULK-ORDER-01JC9A0DA4E00380F",
+        "object": "order",
+        "operation": "insert",
+        "status": "queued",
+        "submitted_at": "2026-07-03T15:22:02Z",
+        "total_records": 2,
+        "processed_records": 0,
+        "queue_position": 1
+    },
+    "success": true,
+    "metadata": {}
+}
+```
+
+---
+
+**Step 5 — Poll until terminal**
+
+Fetch the job by id until `status` is one of the terminal values —
+`succeeded`, `partial_success`, `failed`, or `cancelled`. Bound the loop
+(~20 tries with a short sleep) so it can never hang. Bulk endpoints sit behind
+their own rate-limit bucket, so polling does not consume your normal REST budget
+— but still poll politely.
+
+**Request \[[Create API Key](https://ultracart.atlassian.net/wiki/spaces/ucdoc/pages/38688545/API+Simple+Key)\]**
+```bash
+JOB_ID="BULK-ORDER-01JC9A0DA4E00380F"
+KEY="fbfa455fa3bc2e019e456ffe06200100122d966fc28870019e456ffe08200100"
+
+for i in $(seq 1 20); do
+  RESPONSE=$(curl -s -X GET "https://secure.ultracart.com/rest/v2/bulk/order/$JOB_ID" \
+    -H "Accept: application/json" \
+    -H "X-UltraCart-Api-Version: 2017-03-01" \
+    -H "x-ultracart-simple-key: $KEY")
+  # Pull "status" out of the JSON without a JSON parser dependency.
+  STATUS=$(printf '%s' "$RESPONSE" | grep -o '"status"[^,]*' | head -1 | sed 's/.*: *"\(.*\)"/\1/')
+  echo "  poll $i: status=$STATUS"
+  case "$STATUS" in
+    succeeded|partial_success|failed|cancelled) break ;;
+  esac
+  sleep 3
+done
+echo "$RESPONSE"
+```
+
+**Response Body** (final poll)
+```json
+{
+    "bulk_job": {
+        "job_id": "BULK-ORDER-01JC9A0DA4E00380F",
+        "object": "order",
+        "operation": "insert",
+        "status": "partial_success",
+        "submitted_at": "2026-07-03T15:22:02Z",
+        "started_at": "2026-07-03T15:22:05Z",
+        "completed_at": "2026-07-03T15:22:11Z",
+        "total_records": 2,
+        "processed_records": 2,
+        "success_count": 1,
+        "fail_count": 1,
+        "duplicate_count": 0,
+        "results_summary_url": "https://uc-bulk-uploads.s3.amazonaws.com/bulk-jobs/DEMO/9a0da4e0-results.ndjson?X-Amz-Signature=EXAMPLESIGNATURE"
+    },
+    "success": true,
+    "metadata": {}
+}
+```
+
+---
+
+**Step 6 — List the failed records**
+
+When `fail_count > 0`, page the job's records filtered to `status=failed`.
+Each failed record reports the `line_number`, echoes the `merchant_record_id`,
+and carries an `error_code` / `error_message` (see the per-record error
+vocabulary in payloads.md — e.g. `invalid_currency`, `invalid_item`,
+`missing_required_field`). Follow `next_cursor` with `&cursor=` until it is null.
+
+**Request \[[Create API Key](https://ultracart.atlassian.net/wiki/spaces/ucdoc/pages/38688545/API+Simple+Key)\]**
+```bash
+curl -X GET "https://secure.ultracart.com/rest/v2/bulk/order/BULK-ORDER-01JC9A0DA4E00380F/records?status=failed&limit=100" \
+  -H "Accept: application/json" \
+  -H "X-UltraCart-Api-Version: 2017-03-01" \
+  -H "x-ultracart-simple-key: fbfa455fa3bc2e019e456ffe06200100122d966fc28870019e456ffe08200100"
+```
+
+**Response Body**
+```json
+{
+    "records": [
+        {
+            "merchant_record_id": "legacy-order-1029385",
+            "line_number": 2,
+            "status": "failed",
+            "error_code": "invalid_item",
+            "error_message": "Item WIDGET-BLUE is not a valid SKU for this merchant."
+        }
+    ],
+    "next_cursor": null,
+    "success": true,
+    "metadata": {}
+}
+```

--- a/curl/bulk/bulkUpsertCustomers.curl
+++ b/curl/bulk/bulkUpsertCustomers.curl
@@ -1,0 +1,237 @@
+Bulk upsert **customers** end-to-end with plain curl, using `operation=upsert`.
+
+"upsert" creates a customer when none is found and otherwise replaces the
+existing one (a full-record replace, identical to `PUT /rest/v2/customer` — a
+field you omit is cleared, it is not a partial merge). Upsert is customer-only
+in v1; submitting `operation=upsert` to `/rest/v2/bulk/order` is a 400.
+
+Identity resolution per line:
+1. The `_merchant_record_id` marker from a prior landing wins (that customer is updated).
+2. No marker -> resolve by the line's `email`; still no match -> insert.
+On success each record reports `action` = `inserted` or `updated`.
+
+See bulkImportOrders.curl for the fully-commented base flow (upload URL, S3 PUT,
+bounded poll); this sample highlights only what differs for upsert.
+
+---
+
+**Step 1 — Build the NDJSON payload**
+
+Each line is what the per-record customer-create endpoint accepts, plus the
+top-level `_merchant_record_id`. When email is your natural key, using it as the
+`_merchant_record_id` makes the bulk dedupe and UC's email-uniqueness agree.
+Minimum viable customer line: `_merchant_record_id` and `email`. One minified
+JSON object per line, LF-separated, no array wrapper.
+
+```bash
+cat > customers.ndjson <<'EOF'
+{"_merchant_record_id":"jane@example.com","email":"jane@example.com","first_name":"Jane","last_name":"Doe","billing":[{"first_name":"Jane","last_name":"Doe","address1":"123 Main St","city":"Austin","state_region":"TX","postal_code":"78701","country_code":"US","default_billing":true}],"tags":["legacy-import"]}
+{"_merchant_record_id":"john@example.com","email":"john@example.com","first_name":"John","last_name":"Smith"}
+EOF
+```
+
+---
+
+**Step 2 — Request a presigned upload URL**
+
+**Request \[[Create API Key](https://ultracart.atlassian.net/wiki/spaces/ucdoc/pages/38688545/API+Simple+Key)\]**
+```bash
+curl -X POST "https://secure.ultracart.com/rest/v2/bulk/customer/upload-url" \
+  -H "Accept: application/json" \
+  -H "X-UltraCart-Api-Version: 2017-03-01" \
+  -H "x-ultracart-simple-key: fbfa455fa3bc2e019e456ffe06200100122d966fc28870019e456ffe08200100"
+```
+
+**Response Body**
+```json
+{
+    "upload_url": "https://uc-bulk-uploads.s3.amazonaws.com/bulk-jobs/DEMO/48210300-1c9d-4a77-b3e1-janeexampleco.ndjson?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=EXAMPLESIGNATURE",
+    "s3_key": "bulk-jobs/DEMO/48210300-1c9d-4a77-b3e1-janeexampleco.ndjson",
+    "expires_at": "2026-07-03T15:37:00Z",
+    "max_records": 100000,
+    "success": true,
+    "metadata": {}
+}
+```
+
+---
+
+**Step 3 — Upload the NDJSON straight to the presigned URL**
+
+Plain HTTP PUT to S3 — no API key, not a REST call. Send the raw bytes with
+`--data-binary` so the newlines survive.
+
+**Request**
+```bash
+curl -X PUT "https://uc-bulk-uploads.s3.amazonaws.com/bulk-jobs/DEMO/48210300-1c9d-4a77-b3e1-janeexampleco.ndjson?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=EXAMPLESIGNATURE" \
+  -H "Content-Type: application/x-ndjson" \
+  --data-binary @customers.ndjson
+```
+
+**Response Headers**
+```html
+Status: 200 OK
+x-amz-request-id: 48210300A1C9D477
+ETag: "b3e1a7d4e5f6a8b9c0d1e2f3a4b5c6d7"
+Content-Length: 0
+Date: Fri, 03 Jul 2026 15:24:10 GMT
+```
+
+---
+
+**Step 4 — Submit the job (operation = upsert)**
+
+The only submit difference vs. insert is `operation: "upsert"`.
+
+**Request \[[Create API Key](https://ultracart.atlassian.net/wiki/spaces/ucdoc/pages/38688545/API+Simple+Key)\]**
+```bash
+curl -X POST "https://secure.ultracart.com/rest/v2/bulk/customer" \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  -H "X-UltraCart-Api-Version: 2017-03-01" \
+  -H "x-ultracart-simple-key: fbfa455fa3bc2e019e456ffe06200100122d966fc28870019e456ffe08200100" \
+  -d $'{
+    "s3_key": "bulk-jobs/DEMO/48210300-1c9d-4a77-b3e1-janeexampleco.ndjson",
+    "operation": "upsert"
+}'
+```
+
+**Response Body**
+```json
+{
+    "bulk_job": {
+        "job_id": "BULK-CUSTOMER-01JC48210300A1C",
+        "object": "customer",
+        "operation": "upsert",
+        "status": "queued",
+        "submitted_at": "2026-07-03T15:24:11Z",
+        "total_records": 2,
+        "processed_records": 0,
+        "queue_position": 1
+    },
+    "success": true,
+    "metadata": {}
+}
+```
+
+---
+
+**Step 5 — Poll until terminal**
+
+Same bounded poll as the order sample: GET the job by id until `status` is
+`succeeded`, `partial_success`, `failed`, or `cancelled`; cap the loop so it
+cannot hang.
+
+**Request \[[Create API Key](https://ultracart.atlassian.net/wiki/spaces/ucdoc/pages/38688545/API+Simple+Key)\]**
+```bash
+JOB_ID="BULK-CUSTOMER-01JC48210300A1C"
+KEY="fbfa455fa3bc2e019e456ffe06200100122d966fc28870019e456ffe08200100"
+
+for i in $(seq 1 20); do
+  RESPONSE=$(curl -s -X GET "https://secure.ultracart.com/rest/v2/bulk/customer/$JOB_ID" \
+    -H "Accept: application/json" \
+    -H "X-UltraCart-Api-Version: 2017-03-01" \
+    -H "x-ultracart-simple-key: $KEY")
+  STATUS=$(printf '%s' "$RESPONSE" | grep -o '"status"[^,]*' | head -1 | sed 's/.*: *"\(.*\)"/\1/')
+  echo "  poll $i: status=$STATUS"
+  case "$STATUS" in
+    succeeded|partial_success|failed|cancelled) break ;;
+  esac
+  sleep 3
+done
+echo "$RESPONSE"
+```
+
+**Response Body** (final poll)
+```json
+{
+    "bulk_job": {
+        "job_id": "BULK-CUSTOMER-01JC48210300A1C",
+        "object": "customer",
+        "operation": "upsert",
+        "status": "partial_success",
+        "submitted_at": "2026-07-03T15:24:11Z",
+        "started_at": "2026-07-03T15:24:14Z",
+        "completed_at": "2026-07-03T15:24:19Z",
+        "total_records": 2,
+        "processed_records": 2,
+        "success_count": 1,
+        "fail_count": 1,
+        "duplicate_count": 0,
+        "results_summary_url": "https://uc-bulk-uploads.s3.amazonaws.com/bulk-jobs/DEMO/48210300-results.ndjson?X-Amz-Signature=EXAMPLESIGNATURE"
+    },
+    "success": true,
+    "metadata": {}
+}
+```
+
+---
+
+**Step 6a — List the successful records and read the `action` field**
+
+On upsert, each successful record tells you whether it created or replaced a
+customer via `action` (`inserted` | `updated`). `action` is present only on
+upsert successes — it is absent for insert-mode results and for failures. Page
+with `status=success`, following `next_cursor` until it is null.
+
+**Request \[[Create API Key](https://ultracart.atlassian.net/wiki/spaces/ucdoc/pages/38688545/API+Simple+Key)\]**
+```bash
+curl -X GET "https://secure.ultracart.com/rest/v2/bulk/customer/BULK-CUSTOMER-01JC48210300A1C/records?status=success&limit=100" \
+  -H "Accept: application/json" \
+  -H "X-UltraCart-Api-Version: 2017-03-01" \
+  -H "x-ultracart-simple-key: fbfa455fa3bc2e019e456ffe06200100122d966fc28870019e456ffe08200100"
+```
+
+**Response Body**
+```json
+{
+    "records": [
+        {
+            "merchant_record_id": "jane@example.com",
+            "line_number": 1,
+            "status": "success",
+            "action": "updated",
+            "uc_id": "DEMO-00482103"
+        }
+    ],
+    "next_cursor": null,
+    "success": true,
+    "metadata": {}
+}
+```
+
+---
+
+**Step 6b — List the failed records**
+
+When `fail_count > 0`, page the records filtered to `status=failed`. For upsert
+the notable code is `email_conflict`: the line's email already belongs to a
+different customer than the one the `_merchant_record_id` marker resolved to, so
+the record fails rather than moving the email. (`customer_email_already_exists`
+is the insert-mode analog when the marker was not the email.)
+
+**Request \[[Create API Key](https://ultracart.atlassian.net/wiki/spaces/ucdoc/pages/38688545/API+Simple+Key)\]**
+```bash
+curl -X GET "https://secure.ultracart.com/rest/v2/bulk/customer/BULK-CUSTOMER-01JC48210300A1C/records?status=failed&limit=100" \
+  -H "Accept: application/json" \
+  -H "X-UltraCart-Api-Version: 2017-03-01" \
+  -H "x-ultracart-simple-key: fbfa455fa3bc2e019e456ffe06200100122d966fc28870019e456ffe08200100"
+```
+
+**Response Body**
+```json
+{
+    "records": [
+        {
+            "merchant_record_id": "john@example.com",
+            "line_number": 2,
+            "status": "failed",
+            "error_code": "email_conflict",
+            "error_message": "Email john@example.com already belongs to a different customer than the _merchant_record_id marker resolved to."
+        }
+    ],
+    "next_cursor": null,
+    "success": true,
+    "metadata": {}
+}
+```

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.ultracart</groupId>
             <artifactId>rest-sdk</artifactId>
-            <version>4.1.97</version>
+            <version>4.1.109</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/java/src/bulk/BulkImportOrders.java
+++ b/java/src/bulk/BulkImportOrders.java
@@ -1,0 +1,210 @@
+package bulk;
+
+import com.google.gson.Gson;
+import com.ultracart.admin.v2.BulkApi;
+import com.ultracart.admin.v2.models.BulkJob;
+import com.ultracart.admin.v2.models.BulkJobRequest;
+import com.ultracart.admin.v2.models.BulkJobResponse;
+import com.ultracart.admin.v2.models.BulkRecord;
+import com.ultracart.admin.v2.models.BulkRecordsResponse;
+import com.ultracart.admin.v2.models.BulkUploadUrlResponse;
+import common.Constants;
+
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Bulk import orders - end-to-end lifecycle.
+ * <p>
+ * The bulk API is a throughput multiplier for the per-record REST endpoints: you
+ * upload an NDJSON file of records, submit one job, then poll it to completion.
+ * <p>
+ * Flow demonstrated here:
+ * 1. Build an NDJSON payload (one order per line, each with a stable _merchant_record_id).
+ * 2. Ask the Bulk API for a presigned S3 upload URL.
+ * 3. PUT the NDJSON bytes straight to that URL (this step does NOT go through the SDK).
+ * 4. Submit the job. Orders are insert-only; operation defaults to "insert".
+ * 5. Poll the job until it reaches a terminal status.
+ * 6. Print the counts and list any failed records.
+ * <p>
+ * For create-or-update semantics, see BulkUpsertCustomers.java (customer upsert).
+ */
+public class BulkImportOrders {
+
+    private static final String OBJECT_TYPE = "order";
+
+    // The job is done once it reaches one of these; bound the poll so it can't hang.
+    private static final EnumSet<BulkJob.StatusEnum> TERMINAL = EnumSet.of(
+            BulkJob.StatusEnum.SUCCEEDED,
+            BulkJob.StatusEnum.PARTIAL_SUCCESS,
+            BulkJob.StatusEnum.FAILED,
+            BulkJob.StatusEnum.CANCELLED);
+
+    private static final int MAX_POLLS = 20;
+    private static final long POLL_INTERVAL_MS = 3000L;
+
+    public static void execute() throws Exception {
+
+        // Don't use verifySsl=false in production.
+        BulkApi bulkApi = new BulkApi(Constants.API_KEY, Constants.VERIFY_SSL_FLAG, Constants.DEBUG_MODE);
+
+        // --- 1. Build the NDJSON payload ---------------------------------------
+        // Each line is exactly what POST /rest/v2/order accepts, PLUS a top-level
+        // _merchant_record_id - the bulk-surface dedupe key. Use a STABLE value
+        // derived from your source system (e.g. the legacy order id), NOT a fresh
+        // UUID, so that re-running a fixed file collapses to the original landing
+        // instead of re-inserting.
+        //
+        // NOTE: _merchant_record_id is a bulk-surface field, not an OrderApi model
+        // field, so we build each line as a plain Map rather than an SDK model.
+        List<Map<String, Object>> orders = new ArrayList<>();
+
+        orders.add(obj(
+                "_merchant_record_id", "legacy-order-1029384",
+                "merchant_order_id", "ORD-1029384",
+                "creation_dts", "2023-11-14T09:22:00Z",
+                "currency_code", "USD",
+                "total", 79.50,
+                "customer_profile", obj("email", "jane@example.com"),
+                "items", Arrays.asList(
+                        obj("merchant_item_id", "WIDGET-RED",
+                                "quantity", 2,
+                                "unit_cost", obj("currency_code", "USD", "value", 35.00))),
+                "shipping", obj(
+                        "ship_to", obj(
+                                "first_name", "Jane", "last_name", "Doe", "address1", "123 Main St",
+                                "city", "Austin", "state_region", "TX", "postal_code", "78701",
+                                "country_code", "US"),
+                        "shipping_method", "Standard")));
+
+        orders.add(obj(
+                "_merchant_record_id", "legacy-order-1029385",
+                "merchant_order_id", "ORD-1029385",
+                "creation_dts", "2023-11-15T14:03:00Z",
+                "currency_code", "USD",
+                "total", 35.00,
+                "customer_profile", obj("email", "john@example.com"),
+                "items", Arrays.asList(
+                        obj("merchant_item_id", "WIDGET-BLUE",
+                                "quantity", 1,
+                                "unit_cost", obj("currency_code", "USD", "value", 35.00)))));
+
+        // NDJSON = one minified JSON object per line, LF-separated. Do NOT wrap the
+        // records in a JSON array and do NOT pretty-print - the worker parses the
+        // file line by line. (common.JSON pretty-prints, so use a compact Gson here.)
+        Gson gson = new Gson();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < orders.size(); i++) {
+            if (i > 0) {
+                sb.append('\n');
+            }
+            sb.append(gson.toJson(orders.get(i)));
+        }
+        byte[] ndjson = sb.toString().getBytes(StandardCharsets.UTF_8);
+
+        // --- 2. Get a presigned upload URL -------------------------------------
+        BulkUploadUrlResponse uploadUrlResponse = bulkApi.bulkGenerateUploadUrl(OBJECT_TYPE);
+        String uploadUrl = uploadUrlResponse.getUploadUrl();
+        String s3Key = uploadUrlResponse.getS3Key();
+        System.out.println("Upload URL issued (s3_key=" + s3Key
+                + ", max_records=" + uploadUrlResponse.getMaxRecords() + ").");
+
+        // --- 3. Upload the NDJSON straight to the presigned URL ----------------
+        // A plain HTTP PUT to S3 - this does NOT go through the SDK.
+        uploadToS3(uploadUrl, ndjson);
+        System.out.println("Uploaded " + orders.size() + " records (" + ndjson.length + " bytes).");
+
+        // --- 4. Submit the job -------------------------------------------------
+        BulkJobRequest request = new BulkJobRequest();
+        request.setS3Key(s3Key);
+        request.setOperation(BulkJobRequest.OperationEnum.INSERT); // default for orders; shown for clarity
+        // request.setWebhookUrl("https://example.com/hooks/bulk"); // optional one-shot completion POST
+
+        BulkJobResponse submitResponse = bulkApi.bulkSubmitJob(OBJECT_TYPE, request);
+        BulkJob job = submitResponse.getBulkJob();
+        String jobId = job.getJobId();
+        System.out.println("Submitted job " + jobId + " (status=" + job.getStatus() + ").");
+
+        // --- 5. Poll until terminal --------------------------------------------
+        // Bulk endpoints sit behind their own rate-limit bucket, so polling does not
+        // consume your normal REST budget - but still poll politely and bound it.
+        for (int poll = 0; poll < MAX_POLLS && !TERMINAL.contains(job.getStatus()); poll++) {
+            Thread.sleep(POLL_INTERVAL_MS);
+            job = bulkApi.bulkGetJob(OBJECT_TYPE, jobId).getBulkJob();
+            System.out.println("  status=" + job.getStatus()
+                    + " processed=" + nz(job.getProcessedRecords()) + "/" + nz(job.getTotalRecords()));
+        }
+
+        if (!TERMINAL.contains(job.getStatus())) {
+            System.out.println("Gave up polling after " + MAX_POLLS + " tries; job " + jobId
+                    + " still " + job.getStatus() + ".");
+            return;
+        }
+
+        // --- 6. Report ---------------------------------------------------------
+        System.out.println("\nJob " + jobId + " finished: " + job.getStatus());
+        System.out.println("  success=" + nz(job.getSuccessCount())
+                + " failed=" + nz(job.getFailCount())
+                + " duplicate=" + nz(job.getDuplicateCount()));
+
+        if (job.getFailCount() != null && job.getFailCount() > 0) {
+            System.out.println("\nFailed records:");
+            String cursor = null;
+            do {
+                BulkRecordsResponse recordsResponse =
+                        bulkApi.bulkGetJobRecords(OBJECT_TYPE, jobId, "failed", cursor, 100);
+                for (BulkRecord record : recordsResponse.getRecords()) {
+                    System.out.println("  line " + record.getLineNumber()
+                            + " [" + record.getMerchantRecordId() + "] "
+                            + record.getErrorCode() + ": " + record.getErrorMessage());
+                }
+                cursor = recordsResponse.getNextCursor();
+            } while (cursor != null);
+        }
+    }
+
+    /**
+     * Raw HTTP PUT of the NDJSON bytes to the presigned URL. Uses HttpURLConnection
+     * so the sample compiles on Java 8 (no dependency on java.net.http).
+     */
+    private static void uploadToS3(String uploadUrl, byte[] body) throws Exception {
+        HttpURLConnection conn = (HttpURLConnection) new URL(uploadUrl).openConnection();
+        try {
+            conn.setDoOutput(true);
+            conn.setRequestMethod("PUT");
+            conn.setRequestProperty("Content-Type", "application/x-ndjson");
+            conn.setFixedLengthStreamingMode(body.length);
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(body);
+            }
+            int status = conn.getResponseCode();
+            if (status < 200 || status >= 300) {
+                throw new RuntimeException("Upload PUT failed: " + status + " " + conn.getResponseMessage());
+            }
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    /** Build an ordered Map from alternating key/value arguments. */
+    private static Map<String, Object> obj(Object... kv) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        for (int i = 0; i < kv.length; i += 2) {
+            m.put((String) kv[i], kv[i + 1]);
+        }
+        return m;
+    }
+
+    /** null-safe integer for display. */
+    private static int nz(Integer value) {
+        return value == null ? 0 : value;
+    }
+}

--- a/java/src/bulk/BulkUpsertCustomers.java
+++ b/java/src/bulk/BulkUpsertCustomers.java
@@ -1,0 +1,197 @@
+package bulk;
+
+import com.google.gson.Gson;
+import com.ultracart.admin.v2.BulkApi;
+import com.ultracart.admin.v2.models.BulkJob;
+import com.ultracart.admin.v2.models.BulkJobRequest;
+import com.ultracart.admin.v2.models.BulkJobResponse;
+import com.ultracart.admin.v2.models.BulkRecord;
+import com.ultracart.admin.v2.models.BulkRecordsResponse;
+import com.ultracart.admin.v2.models.BulkUploadUrlResponse;
+import common.Constants;
+
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Bulk upsert customers - end-to-end lifecycle with operation="upsert".
+ * <p>
+ * "upsert" creates a customer when none is found and otherwise replaces the
+ * existing one (a full-record replace, identical to PUT /rest/v2/customer - a
+ * field you omit is cleared, it is not a partial merge). Upsert is customer-only
+ * in v1; submitting operation="upsert" to /rest/v2/bulk/order is a 400.
+ * <p>
+ * Identity resolution per line:
+ * 1. The _merchant_record_id marker from a prior landing wins (that customer is updated).
+ * 2. No marker -> resolve by the line's email; still no match -> insert.
+ * On success each record reports action="inserted" or action="updated".
+ * <p>
+ * See BulkImportOrders.java for the fully-commented base flow; this sample
+ * highlights only what differs for upsert.
+ */
+public class BulkUpsertCustomers {
+
+    private static final String OBJECT_TYPE = "customer";
+
+    private static final EnumSet<BulkJob.StatusEnum> TERMINAL = EnumSet.of(
+            BulkJob.StatusEnum.SUCCEEDED,
+            BulkJob.StatusEnum.PARTIAL_SUCCESS,
+            BulkJob.StatusEnum.FAILED,
+            BulkJob.StatusEnum.CANCELLED);
+
+    private static final int MAX_POLLS = 20;
+    private static final long POLL_INTERVAL_MS = 3000L;
+
+    public static void execute() throws Exception {
+
+        // Don't use verifySsl=false in production.
+        BulkApi bulkApi = new BulkApi(Constants.API_KEY, Constants.VERIFY_SSL_FLAG, Constants.DEBUG_MODE);
+
+        // Each line is what the per-record customer-create endpoint accepts, plus the
+        // top-level _merchant_record_id. When email is your natural key, using it as
+        // the _merchant_record_id makes the bulk dedupe and UC's email-uniqueness
+        // agree. Build each line as a plain Map (not an SDK model) so the bulk-only
+        // _merchant_record_id field rides along.
+        List<Map<String, Object>> customers = new ArrayList<>();
+
+        customers.add(obj(
+                "_merchant_record_id", "jane@example.com",
+                "email", "jane@example.com",
+                "first_name", "Jane",
+                "last_name", "Doe",
+                "billing", Arrays.asList(
+                        obj("first_name", "Jane", "last_name", "Doe", "address1", "123 Main St",
+                                "city", "Austin", "state_region", "TX", "postal_code", "78701",
+                                "country_code", "US", "default_billing", true)),
+                "tags", Arrays.asList("legacy-import")));
+
+        customers.add(obj(
+                "_merchant_record_id", "john@example.com",
+                "email", "john@example.com",
+                "first_name", "John",
+                "last_name", "Smith"));
+
+        // NDJSON: one minified JSON object per line, LF-separated, no array wrapper.
+        // (common.JSON pretty-prints, so use a compact Gson here.)
+        Gson gson = new Gson();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < customers.size(); i++) {
+            if (i > 0) {
+                sb.append('\n');
+            }
+            sb.append(gson.toJson(customers.get(i)));
+        }
+        byte[] ndjson = sb.toString().getBytes(StandardCharsets.UTF_8);
+
+        BulkUploadUrlResponse uploadUrlResponse = bulkApi.bulkGenerateUploadUrl(OBJECT_TYPE);
+        String uploadUrl = uploadUrlResponse.getUploadUrl();
+        String s3Key = uploadUrlResponse.getS3Key();
+        System.out.println("Upload URL issued (s3_key=" + s3Key + ").");
+
+        uploadToS3(uploadUrl, ndjson);
+        System.out.println("Uploaded " + customers.size() + " customers.");
+
+        // The only submit difference vs. insert: operation = "upsert".
+        BulkJobRequest request = new BulkJobRequest();
+        request.setS3Key(s3Key);
+        request.setOperation(BulkJobRequest.OperationEnum.UPSERT);
+
+        BulkJobResponse submitResponse = bulkApi.bulkSubmitJob(OBJECT_TYPE, request);
+        BulkJob job = submitResponse.getBulkJob();
+        String jobId = job.getJobId();
+        System.out.println("Submitted upsert job " + jobId + " (operation=" + job.getOperation() + ").");
+
+        for (int poll = 0; poll < MAX_POLLS && !TERMINAL.contains(job.getStatus()); poll++) {
+            Thread.sleep(POLL_INTERVAL_MS);
+            job = bulkApi.bulkGetJob(OBJECT_TYPE, jobId).getBulkJob();
+            System.out.println("  status=" + job.getStatus()
+                    + " processed=" + nz(job.getProcessedRecords()) + "/" + nz(job.getTotalRecords()));
+        }
+
+        if (!TERMINAL.contains(job.getStatus())) {
+            System.out.println("Gave up polling after " + MAX_POLLS + " tries; job " + jobId
+                    + " still " + job.getStatus() + ".");
+            return;
+        }
+
+        System.out.println("\nJob " + jobId + " finished: " + job.getStatus());
+        System.out.println("  success=" + nz(job.getSuccessCount())
+                + " failed=" + nz(job.getFailCount())
+                + " duplicate=" + nz(job.getDuplicateCount()));
+
+        // On upsert, each successful record tells you whether it created or replaced
+        // a customer via the "action" field (inserted | updated).
+        System.out.println("\nPer-record actions:");
+        String cursor = null;
+        do {
+            BulkRecordsResponse recordsResponse =
+                    bulkApi.bulkGetJobRecords(OBJECT_TYPE, jobId, "success", cursor, 100);
+            for (BulkRecord record : recordsResponse.getRecords()) {
+                System.out.println("  [" + record.getMerchantRecordId() + "] "
+                        + record.getAction() + " -> uc_id=" + record.getUcId());
+            }
+            cursor = recordsResponse.getNextCursor();
+        } while (cursor != null);
+
+        if (job.getFailCount() != null && job.getFailCount() > 0) {
+            System.out.println("\nFailed records (an email_conflict means the line's email belongs to a "
+                    + "different customer than the marker resolved to):");
+            cursor = null;
+            do {
+                BulkRecordsResponse recordsResponse =
+                        bulkApi.bulkGetJobRecords(OBJECT_TYPE, jobId, "failed", cursor, 100);
+                for (BulkRecord record : recordsResponse.getRecords()) {
+                    System.out.println("  line " + record.getLineNumber()
+                            + " [" + record.getMerchantRecordId() + "] "
+                            + record.getErrorCode() + ": " + record.getErrorMessage());
+                }
+                cursor = recordsResponse.getNextCursor();
+            } while (cursor != null);
+        }
+    }
+
+    /**
+     * Raw HTTP PUT of the NDJSON bytes to the presigned URL. Uses HttpURLConnection
+     * so the sample compiles on Java 8 (no dependency on java.net.http).
+     */
+    private static void uploadToS3(String uploadUrl, byte[] body) throws Exception {
+        HttpURLConnection conn = (HttpURLConnection) new URL(uploadUrl).openConnection();
+        try {
+            conn.setDoOutput(true);
+            conn.setRequestMethod("PUT");
+            conn.setRequestProperty("Content-Type", "application/x-ndjson");
+            conn.setFixedLengthStreamingMode(body.length);
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(body);
+            }
+            int status = conn.getResponseCode();
+            if (status < 200 || status >= 300) {
+                throw new RuntimeException("Upload PUT failed: " + status + " " + conn.getResponseMessage());
+            }
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    /** Build an ordered Map from alternating key/value arguments. */
+    private static Map<String, Object> obj(Object... kv) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        for (int i = 0; i < kv.length; i += 2) {
+            m.put((String) kv[i], kv[i + 1]);
+        }
+        return m;
+    }
+
+    /** null-safe integer for display. */
+    private static int nz(Integer value) {
+        return value == null ? 0 : value;
+    }
+}

--- a/java/src/webhook/GetWebhookLogSummaries.java
+++ b/java/src/webhook/GetWebhookLogSummaries.java
@@ -26,7 +26,23 @@ public class GetWebhookLogSummaries {
        int webhookOid = 123456789; // if you don't know this, use getWebhooks to find your webhook, then get its oid.
        String since = Instant.now().minus(10, ChronoUnit.DAYS).toString(); // get the last 10 days
        // Pay attention to whether limit or offset comes first in the method signature. UltraCart is not consistent with their ordering.
-       WebhookLogSummariesResponse apiResponse = webhookApi.getWebhookLogSummaries(webhookOid, limit, offset, since);
+       // The method also accepts optional server-side filters (request id, date range, status, success, event,
+       // order id, request body, duration); pass null for the ones you don't need. This sample only paginates
+       // and constrains to the last 10 days via "since".
+       WebhookLogSummariesResponse apiResponse = webhookApi.getWebhookLogSummaries(
+               webhookOid, // webhookOid
+               null,       // requestId
+               null,       // beginDate
+               null,       // endDate
+               null,       // status
+               null,       // success
+               null,       // event
+               null,       // orderId
+               null,       // request
+               null,       // duration
+               limit,      // limit
+               offset,     // offset
+               since);     // since
 
        if (apiResponse.getWebhookLogSummaries() != null) {
            return apiResponse.getWebhookLogSummaries();

--- a/javascript/api.js
+++ b/javascript/api.js
@@ -1,6 +1,7 @@
 import {
     ApiClient,
     AutoOrderApi,
+    BulkApi,
     ChannelPartnerApi,
     CheckoutApi,
     CouponApi,
@@ -18,6 +19,7 @@ apiClient.authentications.ultraCartSimpleApiKey.apiKey = apiKey;
 // console.log('apiClient', apiClient);
 
 export const autoOrderApi = new AutoOrderApi(apiClient);
+export const bulkApi = new BulkApi(apiClient);
 export const channelPartnerApi = new ChannelPartnerApi(apiClient);
 export const checkoutApi = new CheckoutApi(apiClient);
 export const couponApi = new CouponApi(apiClient);

--- a/javascript/bulk/bulkImportOrders.js
+++ b/javascript/bulk/bulkImportOrders.js
@@ -1,0 +1,135 @@
+// Bulk import orders — end-to-end lifecycle.
+//
+// The bulk API is a throughput multiplier for the per-record REST endpoints: you
+// upload an NDJSON file of records, submit one job, then poll it to completion.
+//
+// Flow demonstrated here:
+//   1. Build an NDJSON payload (one order per line, each with a stable _merchant_record_id).
+//   2. Ask the Bulk API for a presigned S3 upload URL.
+//   3. PUT the NDJSON bytes straight to that URL (this step does NOT go through the SDK).
+//   4. Submit the job. Orders are insert-only; operation defaults to "insert".
+//   5. Poll the job until it reaches a terminal status.
+//   6. Print the counts and list any failed records.
+//
+// For create-or-update semantics, see bulkUpsertCustomers.js (customer upsert).
+
+import { bulkApi } from '../api.js';
+import { BulkJobRequest } from 'ultra_cart_rest_api_v2';
+
+const OBJECT_TYPE = 'order';
+
+// --- 1. Build the NDJSON payload -------------------------------------------
+// Each line is exactly what POST /rest/v2/order accepts, PLUS a top-level
+// _merchant_record_id — the bulk-surface dedupe key. Use a STABLE value derived
+// from your source system (e.g. the legacy order id), NOT a fresh UUID, so that
+// re-running a fixed file collapses to the original landing instead of re-inserting.
+const orders = [
+    {
+        _merchant_record_id: 'legacy-order-1029384',
+        merchant_order_id: 'ORD-1029384',
+        creation_dts: '2023-11-14T09:22:00Z',
+        currency_code: 'USD',
+        total: 79.50,
+        customer_profile: { email: 'jane@example.com' },
+        items: [
+            { merchant_item_id: 'WIDGET-RED', quantity: 2, unit_cost: { currency_code: 'USD', value: 35.00 } }
+        ],
+        shipping: {
+            ship_to: {
+                first_name: 'Jane', last_name: 'Doe', address1: '123 Main St',
+                city: 'Austin', state_region: 'TX', postal_code: '78701', country_code: 'US'
+            },
+            shipping_method: 'Standard'
+        }
+    },
+    {
+        _merchant_record_id: 'legacy-order-1029385',
+        merchant_order_id: 'ORD-1029385',
+        creation_dts: '2023-11-15T14:03:00Z',
+        currency_code: 'USD',
+        total: 35.00,
+        customer_profile: { email: 'john@example.com' },
+        items: [
+            { merchant_item_id: 'WIDGET-BLUE', quantity: 1, unit_cost: { currency_code: 'USD', value: 35.00 } }
+        ]
+    }
+];
+
+// NDJSON = one minified JSON object per line, LF-separated. Do NOT wrap the records
+// in a JSON array and do NOT pretty-print — the worker parses the file line by line.
+const ndjson = orders.map(order => JSON.stringify(order)).join('\n');
+
+// The generated JS SDK uses (error, data, response) callbacks. Wrap them in a
+// promise so the multi-step flow reads top to bottom.
+function call(invoke) {
+    return new Promise((resolve, reject) => invoke((error, data) => (error ? reject(error) : resolve(data))));
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function main() {
+    // --- 2. Get a presigned upload URL --------------------------------------
+    const uploadUrlResponse = await call((cb) => bulkApi.bulkGenerateUploadUrl(OBJECT_TYPE, cb));
+    const uploadUrl = uploadUrlResponse.upload_url;
+    const s3Key = uploadUrlResponse.s3_key;
+    console.log(`Upload URL issued (s3_key=${s3Key}, max_records=${uploadUrlResponse.max_records}).`);
+
+    // --- 3. Upload the NDJSON straight to the presigned URL ------------------
+    // A plain HTTP PUT to S3. `fetch` is built into Node 18+.
+    const putResponse = await fetch(uploadUrl, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/x-ndjson' },
+        body: ndjson
+    });
+    if (!putResponse.ok) {
+        throw new Error(`Upload PUT failed: ${putResponse.status} ${putResponse.statusText}`);
+    }
+    console.log(`Uploaded ${orders.length} records (${Buffer.byteLength(ndjson)} bytes).`);
+
+    // --- 4. Submit the job --------------------------------------------------
+    const request = new BulkJobRequest();
+    request.s3_key = s3Key;
+    request.operation = 'insert'; // default for orders; shown here for clarity
+    // request.webhook_url = 'https://example.com/hooks/bulk'; // optional one-shot completion POST
+
+    const submitResponse = await call((cb) => bulkApi.bulkSubmitJob(OBJECT_TYPE, request, cb));
+    const jobId = submitResponse.bulk_job.job_id;
+    console.log(`Submitted job ${jobId} (status=${submitResponse.bulk_job.status}).`);
+
+    // --- 5. Poll until terminal ---------------------------------------------
+    // Bulk endpoints sit behind their own rate-limit bucket, so polling does not
+    // consume your normal REST budget — but still poll politely.
+    const TERMINAL = ['succeeded', 'partial_success', 'failed', 'cancelled'];
+    let job = submitResponse.bulk_job;
+    while (!TERMINAL.includes(job.status)) {
+        await sleep(3000);
+        const jobResponse = await call((cb) => bulkApi.bulkGetJob(OBJECT_TYPE, jobId, cb));
+        job = jobResponse.bulk_job;
+        console.log(`  status=${job.status} processed=${job.processed_records ?? 0}/${job.total_records ?? '?'}`);
+    }
+
+    // --- 6. Report ----------------------------------------------------------
+    console.log(`\nJob ${jobId} finished: ${job.status}`);
+    console.log(`  success=${job.success_count} failed=${job.fail_count} duplicate=${job.duplicate_count}`);
+
+    if (job.fail_count > 0) {
+        console.log('\nFailed records:');
+        let cursor;
+        do {
+            const opts = { status: 'failed', limit: 100 };
+            if (cursor) opts.cursor = cursor;
+            const recordsResponse = await call((cb) => bulkApi.bulkGetJobRecords(OBJECT_TYPE, jobId, opts, cb));
+            for (const record of recordsResponse.records) {
+                console.log(`  line ${record.line_number} [${record.merchant_record_id}] ${record.error_code}: ${record.error_message}`);
+            }
+            cursor = recordsResponse.next_cursor;
+        } while (cursor);
+    }
+}
+
+main().catch((error) => {
+    // SDK errors carry the HTTP response body on error.response.text
+    const detail = error && error.response && error.response.text ? error.response.text : (error.message || error);
+    console.error('Bulk import failed:', detail);
+    process.exit(1);
+});

--- a/javascript/bulk/bulkUpsertCustomers.js
+++ b/javascript/bulk/bulkUpsertCustomers.js
@@ -1,0 +1,122 @@
+// Bulk upsert customers — end-to-end lifecycle with operation="upsert".
+//
+// "upsert" creates a customer when none is found and otherwise replaces the
+// existing one (a full-record replace, identical to PUT /rest/v2/customer — a
+// field you omit is cleared, it is not a partial merge). Upsert is customer-only
+// in v1; submitting operation="upsert" to /rest/v2/bulk/order is a 400.
+//
+// Identity resolution per line:
+//   1. The _merchant_record_id marker from a prior landing wins (that customer is updated).
+//   2. No marker -> resolve by the line's email; still no match -> insert.
+// On success each record reports action="inserted" or action="updated".
+//
+// See bulkImportOrders.js for the fully-commented base flow; this sample highlights
+// only what differs for upsert.
+
+import { bulkApi } from '../api.js';
+import { BulkJobRequest } from 'ultra_cart_rest_api_v2';
+
+const OBJECT_TYPE = 'customer';
+
+// Each line is what the per-record customer-create endpoint accepts, plus the
+// top-level _merchant_record_id. When email is your natural key, using it as the
+// _merchant_record_id makes the bulk dedupe and UC's email-uniqueness agree.
+const customers = [
+    {
+        _merchant_record_id: 'jane@example.com',
+        email: 'jane@example.com',
+        first_name: 'Jane',
+        last_name: 'Doe',
+        billing: [{
+            first_name: 'Jane', last_name: 'Doe', address1: '123 Main St',
+            city: 'Austin', state_region: 'TX', postal_code: '78701', country_code: 'US', default_billing: true
+        }],
+        tags: ['legacy-import']
+    },
+    {
+        _merchant_record_id: 'john@example.com',
+        email: 'john@example.com',
+        first_name: 'John',
+        last_name: 'Smith'
+    }
+];
+
+const ndjson = customers.map((customer) => JSON.stringify(customer)).join('\n');
+
+function call(invoke) {
+    return new Promise((resolve, reject) => invoke((error, data) => (error ? reject(error) : resolve(data))));
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function main() {
+    const uploadUrlResponse = await call((cb) => bulkApi.bulkGenerateUploadUrl(OBJECT_TYPE, cb));
+    const uploadUrl = uploadUrlResponse.upload_url;
+    const s3Key = uploadUrlResponse.s3_key;
+    console.log(`Upload URL issued (s3_key=${s3Key}).`);
+
+    const putResponse = await fetch(uploadUrl, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/x-ndjson' },
+        body: ndjson
+    });
+    if (!putResponse.ok) {
+        throw new Error(`Upload PUT failed: ${putResponse.status} ${putResponse.statusText}`);
+    }
+    console.log(`Uploaded ${customers.length} customers.`);
+
+    // The only submit difference vs. insert: operation = "upsert".
+    const request = new BulkJobRequest();
+    request.s3_key = s3Key;
+    request.operation = 'upsert';
+
+    const submitResponse = await call((cb) => bulkApi.bulkSubmitJob(OBJECT_TYPE, request, cb));
+    const jobId = submitResponse.bulk_job.job_id;
+    console.log(`Submitted upsert job ${jobId} (operation=${submitResponse.bulk_job.operation}).`);
+
+    const TERMINAL = ['succeeded', 'partial_success', 'failed', 'cancelled'];
+    let job = submitResponse.bulk_job;
+    while (!TERMINAL.includes(job.status)) {
+        await sleep(3000);
+        const jobResponse = await call((cb) => bulkApi.bulkGetJob(OBJECT_TYPE, jobId, cb));
+        job = jobResponse.bulk_job;
+        console.log(`  status=${job.status} processed=${job.processed_records ?? 0}/${job.total_records ?? '?'}`);
+    }
+
+    console.log(`\nJob ${jobId} finished: ${job.status}`);
+    console.log(`  success=${job.success_count} failed=${job.fail_count} duplicate=${job.duplicate_count}`);
+
+    // On upsert, each successful record tells you whether it created or replaced a
+    // customer via the "action" field (inserted | updated).
+    console.log('\nPer-record actions:');
+    let cursor;
+    do {
+        const opts = { status: 'success', limit: 100 };
+        if (cursor) opts.cursor = cursor;
+        const recordsResponse = await call((cb) => bulkApi.bulkGetJobRecords(OBJECT_TYPE, jobId, opts, cb));
+        for (const record of recordsResponse.records) {
+            console.log(`  [${record.merchant_record_id}] ${record.action} -> uc_id=${record.uc_id}`);
+        }
+        cursor = recordsResponse.next_cursor;
+    } while (cursor);
+
+    if (job.fail_count > 0) {
+        console.log('\nFailed records (an email_conflict means the line\'s email belongs to a different customer than the marker resolved to):');
+        cursor = undefined;
+        do {
+            const opts = { status: 'failed', limit: 100 };
+            if (cursor) opts.cursor = cursor;
+            const recordsResponse = await call((cb) => bulkApi.bulkGetJobRecords(OBJECT_TYPE, jobId, opts, cb));
+            for (const record of recordsResponse.records) {
+                console.log(`  line ${record.line_number} [${record.merchant_record_id}] ${record.error_code}: ${record.error_message}`);
+            }
+            cursor = recordsResponse.next_cursor;
+        } while (cursor);
+    }
+}
+
+main().catch((error) => {
+    const detail = error && error.response && error.response.text ? error.response.text : (error.message || error);
+    console.error('Bulk upsert failed:', detail);
+    process.exit(1);
+});

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "luxon": "3.2.1",
         "ssl-root-cas": "^1.2.3",
-        "ultra_cart_rest_api_v2": "4.1.97"
+        "ultra_cart_rest_api_v2": "4.1.109"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1252,9 +1252,10 @@
       }
     },
     "node_modules/ultra_cart_rest_api_v2": {
-      "version": "4.1.97",
-      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.97.tgz",
-      "integrity": "sha512-56vvBLAU4Rfa2SwWzBQO9J+qt1qocHXO8ep577VjNIdtzqUOAXH4dwUrgTvAmMeianESEIM8s7ZDZx3DcrcpZg==",
+      "version": "4.1.109",
+      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.109.tgz",
+      "integrity": "sha512-Rosqri2yLkuuguojz+PMS6COp+Vm2A0VkX9kwmw9BhD4k/toO/OQ1X3hfwmacT5WKUOeIPlSUlytoSFU/77VCw==",
+      "license": "Unlicense",
       "dependencies": {
         "@babel/cli": "^7.0.0",
         "superagent": "^5.3.0"
@@ -2201,9 +2202,9 @@
       }
     },
     "ultra_cart_rest_api_v2": {
-      "version": "4.1.97",
-      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.97.tgz",
-      "integrity": "sha512-56vvBLAU4Rfa2SwWzBQO9J+qt1qocHXO8ep577VjNIdtzqUOAXH4dwUrgTvAmMeianESEIM8s7ZDZx3DcrcpZg==",
+      "version": "4.1.109",
+      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.109.tgz",
+      "integrity": "sha512-Rosqri2yLkuuguojz+PMS6COp+Vm2A0VkX9kwmw9BhD4k/toO/OQ1X3hfwmacT5WKUOeIPlSUlytoSFU/77VCw==",
       "requires": {
         "@babel/cli": "^7.0.0",
         "superagent": "^5.3.0"

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "luxon": "3.2.1",
     "ssl-root-cas": "^1.2.3",
-    "ultra_cart_rest_api_v2": "4.1.97"
+    "ultra_cart_rest_api_v2": "4.1.109"
   }
 }

--- a/php/bulk/bulkImportOrders.php
+++ b/php/bulk/bulkImportOrders.php
@@ -1,0 +1,179 @@
+<?php
+
+/*
+ * Bulk import orders — end-to-end lifecycle.
+ *
+ * The bulk API is a throughput multiplier for the per-record REST endpoints: you
+ * upload an NDJSON file of records, submit one job, then poll it to completion.
+ *
+ * Flow demonstrated here:
+ *   1. Build an NDJSON payload (one order per line, each with a stable _merchant_record_id).
+ *   2. Ask the Bulk API for a presigned S3 upload URL.
+ *   3. PUT the NDJSON bytes straight to that URL (this step does NOT go through the SDK).
+ *   4. Submit the job. Orders are insert-only; operation defaults to "insert".
+ *   5. Poll the job until it reaches a terminal status.
+ *   6. Print the counts and list any failed records.
+ *
+ * For create-or-update semantics, see bulkUpsertCustomers.php (customer upsert).
+ *
+ * This example is written for our run_samples.sh harness, so it prints plain
+ * human-readable text rather than HTML.
+ */
+
+use ultracart\v2\ApiException;
+use ultracart\v2\models\BulkJobRequest;
+
+require_once '../vendor/autoload.php';
+require_once '../samples.php';
+
+const OBJECT_TYPE = 'order';
+
+// Terminal job statuses — polling stops once the job reaches any of these.
+const TERMINAL_STATUSES = ['succeeded', 'partial_success', 'failed', 'cancelled'];
+
+// Bound the poll so a stuck job can't hang the sample.
+const MAX_POLL_ATTEMPTS = 20;
+const POLL_SLEEP_SECONDS = 3;
+
+/**
+ * Raw HTTP PUT of the NDJSON bytes to the presigned S3 URL. This deliberately
+ * bypasses the SDK — the upload target is plain S3, not an UltraCart endpoint.
+ *
+ * @throws RuntimeException on a non-2xx response
+ */
+function putNdjson(string $upload_url, string $ndjson): void
+{
+    $ch = curl_init($upload_url);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $ndjson);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/x-ndjson']);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, Constants::VERIFY_SSL);
+    $body = curl_exec($ch);
+    if ($body === false) {
+        $err = curl_error($ch);
+        curl_close($ch);
+        throw new RuntimeException("Upload PUT failed: $err");
+    }
+    $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    if ($status < 200 || $status >= 300) {
+        throw new RuntimeException("Upload PUT failed: HTTP $status");
+    }
+}
+
+try {
+
+    $bulk_api = Samples::getBulkApi();
+
+    // --- 1. Build the NDJSON payload ----------------------------------------
+    // Each line is exactly what POST /rest/v2/order accepts, PLUS a top-level
+    // _merchant_record_id — the bulk-surface dedupe key. Use a STABLE value derived
+    // from your source system (e.g. the legacy order id), NOT a fresh UUID, so that
+    // re-running a fixed file collapses to the original landing instead of re-inserting.
+    //
+    // NOTE: build the lines as PLAIN associative arrays, not SDK model instances —
+    // _merchant_record_id is not an SDK model field, and json_encode of a model would
+    // drop unknown keys and rename the rest.
+    $orders = [
+        [
+            '_merchant_record_id' => 'legacy-order-1029384',
+            'merchant_order_id' => 'ORD-1029384',
+            'creation_dts' => '2023-11-14T09:22:00Z',
+            'currency_code' => 'USD',
+            'total' => 79.50,
+            'customer_profile' => ['email' => 'jane@example.com'],
+            'items' => [
+                ['merchant_item_id' => 'WIDGET-RED', 'quantity' => 2, 'unit_cost' => ['currency_code' => 'USD', 'value' => 35.00]],
+            ],
+            'shipping' => [
+                'ship_to' => [
+                    'first_name' => 'Jane', 'last_name' => 'Doe', 'address1' => '123 Main St',
+                    'city' => 'Austin', 'state_region' => 'TX', 'postal_code' => '78701', 'country_code' => 'US',
+                ],
+                'shipping_method' => 'Standard',
+            ],
+        ],
+        [
+            '_merchant_record_id' => 'legacy-order-1029385',
+            'merchant_order_id' => 'ORD-1029385',
+            'creation_dts' => '2023-11-15T14:03:00Z',
+            'currency_code' => 'USD',
+            'total' => 35.00,
+            'customer_profile' => ['email' => 'john@example.com'],
+            'items' => [
+                ['merchant_item_id' => 'WIDGET-BLUE', 'quantity' => 1, 'unit_cost' => ['currency_code' => 'USD', 'value' => 35.00]],
+            ],
+        ],
+    ];
+
+    // NDJSON = one minified JSON object per line, LF-separated. Do NOT wrap the records
+    // in a JSON array and do NOT pretty-print — the worker parses the file line by line.
+    $lines = array_map(
+        static fn(array $order): string => json_encode($order, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+        $orders
+    );
+    $ndjson = implode("\n", $lines);
+
+    // --- 2. Get a presigned upload URL --------------------------------------
+    $upload_url_response = $bulk_api->bulkGenerateUploadUrl(OBJECT_TYPE);
+    $upload_url = $upload_url_response->getUploadUrl();
+    $s3_key = $upload_url_response->getS3Key();
+    echo 'Upload URL issued (s3_key=' . $s3_key . ', max_records=' . $upload_url_response->getMaxRecords() . ").\n";
+
+    // --- 3. Upload the NDJSON straight to the presigned URL -----------------
+    putNdjson($upload_url, $ndjson);
+    echo 'Uploaded ' . count($orders) . ' records (' . strlen($ndjson) . " bytes).\n";
+
+    // --- 4. Submit the job --------------------------------------------------
+    $request = new BulkJobRequest();
+    $request->setS3Key($s3_key);
+    $request->setOperation('insert'); // default for orders; shown here for clarity
+    // $request->setWebhookUrl('https://example.com/hooks/bulk'); // optional one-shot completion POST
+
+    $submit_response = $bulk_api->bulkSubmitJob(OBJECT_TYPE, $request);
+    $job = $submit_response->getBulkJob();
+    $job_id = $job->getJobId();
+    echo 'Submitted job ' . $job_id . ' (status=' . $job->getStatus() . ").\n";
+
+    // --- 5. Poll until terminal ---------------------------------------------
+    // Bulk endpoints sit behind their own rate-limit bucket, so polling does not
+    // consume your normal REST budget — but still poll politely and bound the loop.
+    $attempts = 0;
+    while (!in_array($job->getStatus(), TERMINAL_STATUSES, true) && $attempts < MAX_POLL_ATTEMPTS) {
+        sleep(POLL_SLEEP_SECONDS);
+        $attempts++;
+        $job = $bulk_api->bulkGetJob(OBJECT_TYPE, $job_id)->getBulkJob();
+        echo '  status=' . $job->getStatus()
+            . ' processed=' . ($job->getProcessedRecords() ?? 0)
+            . '/' . ($job->getTotalRecords() ?? '?') . "\n";
+    }
+
+    // --- 6. Report ----------------------------------------------------------
+    echo "\nJob " . $job_id . ' finished: ' . $job->getStatus() . "\n";
+    echo '  success=' . $job->getSuccessCount()
+        . ' failed=' . $job->getFailCount()
+        . ' duplicate=' . $job->getDuplicateCount() . "\n";
+
+    if ($job->getFailCount() > 0) {
+        echo "\nFailed records:\n";
+        $cursor = null;
+        do {
+            $records_response = $bulk_api->bulkGetJobRecords(OBJECT_TYPE, $job_id, 'failed', $cursor, 100);
+            foreach ($records_response->getRecords() as $record) {
+                echo '  line ' . $record->getLineNumber()
+                    . ' [' . $record->getMerchantRecordId() . '] '
+                    . $record->getErrorCode() . ': ' . $record->getErrorMessage() . "\n";
+            }
+            $cursor = $records_response->getNextCursor();
+        } while ($cursor);
+    }
+
+} catch (ApiException $e) {
+    // SDK errors carry the HTTP response body — the analog of the JS error.response.text.
+    echo 'Bulk import failed: ' . $e->getResponseBody() . "\n";
+    die(1);
+} catch (RuntimeException $e) {
+    echo 'Bulk import failed: ' . $e->getMessage() . "\n";
+    die(1);
+}

--- a/php/bulk/bulkUpsertCustomers.php
+++ b/php/bulk/bulkUpsertCustomers.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * Bulk upsert customers — end-to-end lifecycle with operation="upsert".
+ *
+ * "upsert" creates a customer when none is found and otherwise replaces the
+ * existing one (a full-record replace, identical to PUT /rest/v2/customer — a
+ * field you omit is cleared, it is not a partial merge). Upsert is customer-only
+ * in v1; submitting operation="upsert" to /rest/v2/bulk/order is a 400.
+ *
+ * Identity resolution per line:
+ *   1. The _merchant_record_id marker from a prior landing wins (that customer is updated).
+ *   2. No marker -> resolve by the line's email; still no match -> insert.
+ * On success each record reports action="inserted" or action="updated".
+ *
+ * See bulkImportOrders.php for the fully-commented base flow; this sample highlights
+ * only what differs for upsert.
+ */
+
+use ultracart\v2\ApiException;
+use ultracart\v2\models\BulkJobRequest;
+
+require_once '../vendor/autoload.php';
+require_once '../samples.php';
+
+const OBJECT_TYPE = 'customer';
+
+const TERMINAL_STATUSES = ['succeeded', 'partial_success', 'failed', 'cancelled'];
+const MAX_POLL_ATTEMPTS = 20;
+const POLL_SLEEP_SECONDS = 3;
+
+/**
+ * Raw HTTP PUT of the NDJSON bytes to the presigned S3 URL — bypasses the SDK.
+ *
+ * @throws RuntimeException on a non-2xx response
+ */
+function putNdjson(string $upload_url, string $ndjson): void
+{
+    $ch = curl_init($upload_url);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $ndjson);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/x-ndjson']);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, Constants::VERIFY_SSL);
+    $body = curl_exec($ch);
+    if ($body === false) {
+        $err = curl_error($ch);
+        curl_close($ch);
+        throw new RuntimeException("Upload PUT failed: $err");
+    }
+    $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    if ($status < 200 || $status >= 300) {
+        throw new RuntimeException("Upload PUT failed: HTTP $status");
+    }
+}
+
+try {
+
+    $bulk_api = Samples::getBulkApi();
+
+    // Each line is what the per-record customer-create endpoint accepts, plus the
+    // top-level _merchant_record_id. When email is your natural key, using it as the
+    // _merchant_record_id makes the bulk dedupe and UC's email-uniqueness agree.
+    // Build PLAIN associative arrays, not SDK model instances.
+    $customers = [
+        [
+            '_merchant_record_id' => 'jane@example.com',
+            'email' => 'jane@example.com',
+            'first_name' => 'Jane',
+            'last_name' => 'Doe',
+            'billing' => [[
+                'first_name' => 'Jane', 'last_name' => 'Doe', 'address1' => '123 Main St',
+                'city' => 'Austin', 'state_region' => 'TX', 'postal_code' => '78701',
+                'country_code' => 'US', 'default_billing' => true,
+            ]],
+            'tags' => ['legacy-import'],
+        ],
+        [
+            '_merchant_record_id' => 'john@example.com',
+            'email' => 'john@example.com',
+            'first_name' => 'John',
+            'last_name' => 'Smith',
+        ],
+    ];
+
+    $lines = array_map(
+        static fn(array $customer): string => json_encode($customer, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+        $customers
+    );
+    $ndjson = implode("\n", $lines);
+
+    $upload_url_response = $bulk_api->bulkGenerateUploadUrl(OBJECT_TYPE);
+    $upload_url = $upload_url_response->getUploadUrl();
+    $s3_key = $upload_url_response->getS3Key();
+    echo 'Upload URL issued (s3_key=' . $s3_key . ").\n";
+
+    putNdjson($upload_url, $ndjson);
+    echo 'Uploaded ' . count($customers) . " customers.\n";
+
+    // The only submit difference vs. insert: operation = "upsert".
+    $request = new BulkJobRequest();
+    $request->setS3Key($s3_key);
+    $request->setOperation('upsert');
+
+    $submit_response = $bulk_api->bulkSubmitJob(OBJECT_TYPE, $request);
+    $job = $submit_response->getBulkJob();
+    $job_id = $job->getJobId();
+    echo 'Submitted upsert job ' . $job_id . ' (operation=' . $job->getOperation() . ").\n";
+
+    $attempts = 0;
+    while (!in_array($job->getStatus(), TERMINAL_STATUSES, true) && $attempts < MAX_POLL_ATTEMPTS) {
+        sleep(POLL_SLEEP_SECONDS);
+        $attempts++;
+        $job = $bulk_api->bulkGetJob(OBJECT_TYPE, $job_id)->getBulkJob();
+        echo '  status=' . $job->getStatus()
+            . ' processed=' . ($job->getProcessedRecords() ?? 0)
+            . '/' . ($job->getTotalRecords() ?? '?') . "\n";
+    }
+
+    echo "\nJob " . $job_id . ' finished: ' . $job->getStatus() . "\n";
+    echo '  success=' . $job->getSuccessCount()
+        . ' failed=' . $job->getFailCount()
+        . ' duplicate=' . $job->getDuplicateCount() . "\n";
+
+    // On upsert, each successful record tells you whether it created or replaced a
+    // customer via the "action" field (inserted | updated).
+    echo "\nPer-record actions:\n";
+    $cursor = null;
+    do {
+        $records_response = $bulk_api->bulkGetJobRecords(OBJECT_TYPE, $job_id, 'success', $cursor, 100);
+        foreach ($records_response->getRecords() as $record) {
+            echo '  [' . $record->getMerchantRecordId() . '] '
+                . $record->getAction() . ' -> uc_id=' . $record->getUcId() . "\n";
+        }
+        $cursor = $records_response->getNextCursor();
+    } while ($cursor);
+
+    if ($job->getFailCount() > 0) {
+        echo "\nFailed records (an email_conflict means the line's email belongs to a different customer than the marker resolved to):\n";
+        $cursor = null;
+        do {
+            $records_response = $bulk_api->bulkGetJobRecords(OBJECT_TYPE, $job_id, 'failed', $cursor, 100);
+            foreach ($records_response->getRecords() as $record) {
+                echo '  line ' . $record->getLineNumber()
+                    . ' [' . $record->getMerchantRecordId() . '] '
+                    . $record->getErrorCode() . ': ' . $record->getErrorMessage() . "\n";
+            }
+            $cursor = $records_response->getNextCursor();
+        } while ($cursor);
+    }
+
+} catch (ApiException $e) {
+    echo 'Bulk upsert failed: ' . $e->getResponseBody() . "\n";
+    die(1);
+} catch (RuntimeException $e) {
+    echo 'Bulk upsert failed: ' . $e->getMessage() . "\n";
+    die(1);
+}

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "ultracart/rest_api_v2_sdk_php": "4.1.97"
+        "ultracart/rest_api_v2_sdk_php": "4.1.109"
     },
     "config": {
         "discard-changes": true

--- a/php/samples.php
+++ b/php/samples.php
@@ -2,6 +2,7 @@
 
 require_once 'constants.php';
 
+use ultracart\v2\api\BulkApi;
 use ultracart\v2\api\CustomerApi;
 use ultracart\v2\api\GiftCertificateApi;
 use ultracart\v2\api\OrderApi;
@@ -56,6 +57,12 @@ class Samples
     public static function getFraudApi(): FraudApi
     {
         return FraudApi::usingApiKey(Constants::API_KEY, Constants::MAX_RETRY_SECONDS,
+            Constants::VERIFY_SSL, Constants::DEBUG);
+    }
+
+    public static function getBulkApi(): BulkApi
+    {
+        return BulkApi::usingApiKey(Constants::API_KEY, Constants::MAX_RETRY_SECONDS,
             Constants::VERIFY_SSL, Constants::DEBUG);
     }
 

--- a/python/bulk/bulk_import_orders.py
+++ b/python/bulk/bulk_import_orders.py
@@ -1,0 +1,151 @@
+# Bulk import orders - end-to-end lifecycle.
+#
+# The bulk API is a throughput multiplier for the per-record REST endpoints: you
+# upload an NDJSON file of records, submit one job, then poll it to completion.
+#
+# Flow demonstrated here:
+#   1. Build an NDJSON payload (one order per line, each with a stable _merchant_record_id).
+#   2. Ask the Bulk API for a presigned S3 upload URL.
+#   3. PUT the NDJSON bytes straight to that URL (this step does NOT go through the SDK).
+#   4. Submit the job. Orders are insert-only; operation defaults to "insert".
+#   5. Poll the job until it reaches a terminal status.
+#   6. Print the counts and list any failed records.
+#
+# For create-or-update semantics, see bulk_upsert_customers.py (customer upsert).
+
+import json
+import time
+import urllib.request
+
+from ultracart.apis import BulkApi
+from ultracart.models import BulkJobRequest
+from ultracart.rest import ApiException
+from samples import api_client
+
+OBJECT_TYPE = 'order'
+
+# Terminal job statuses - stop polling once the job reaches one of these.
+TERMINAL_STATUSES = {'succeeded', 'partial_success', 'failed', 'cancelled'}
+
+# --- 1. Build the NDJSON payload -------------------------------------------
+# Each line is exactly what POST /rest/v2/order accepts, PLUS a top-level
+# _merchant_record_id - the bulk-surface dedupe key. Use a STABLE value derived
+# from your source system (e.g. the legacy order id), NOT a fresh UUID, so that
+# re-running a fixed file collapses to the original landing instead of re-inserting.
+#
+# Build the lines as PLAIN dicts, not SDK model instances: _merchant_record_id is
+# a bulk-surface marker, not a field on the per-record Order model.
+orders = [
+    {
+        '_merchant_record_id': 'legacy-order-1029384',
+        'merchant_order_id': 'ORD-1029384',
+        'creation_dts': '2023-11-14T09:22:00Z',
+        'currency_code': 'USD',
+        'total': 79.50,
+        'customer_profile': {'email': 'jane@example.com'},
+        'items': [
+            {'merchant_item_id': 'WIDGET-RED', 'quantity': 2,
+             'unit_cost': {'currency_code': 'USD', 'value': 35.00}}
+        ],
+        'shipping': {
+            'ship_to': {
+                'first_name': 'Jane', 'last_name': 'Doe', 'address1': '123 Main St',
+                'city': 'Austin', 'state_region': 'TX', 'postal_code': '78701', 'country_code': 'US'
+            },
+            'shipping_method': 'Standard'
+        }
+    },
+    {
+        '_merchant_record_id': 'legacy-order-1029385',
+        'merchant_order_id': 'ORD-1029385',
+        'creation_dts': '2023-11-15T14:03:00Z',
+        'currency_code': 'USD',
+        'total': 35.00,
+        'customer_profile': {'email': 'john@example.com'},
+        'items': [
+            {'merchant_item_id': 'WIDGET-BLUE', 'quantity': 1,
+             'unit_cost': {'currency_code': 'USD', 'value': 35.00}}
+        ]
+    }
+]
+
+# NDJSON = one minified JSON object per line, LF-separated, UTF-8. Do NOT wrap the
+# records in a JSON array and do NOT pretty-print - the worker parses the file line
+# by line. json.dumps with compact separators keeps each record on a single line.
+ndjson = '\n'.join(json.dumps(order, separators=(',', ':')) for order in orders)
+
+
+def main():
+    bulk_api = BulkApi(api_client())
+
+    # --- 2. Get a presigned upload URL --------------------------------------
+    upload_url_response = bulk_api.bulk_generate_upload_url(OBJECT_TYPE)
+    upload_url = upload_url_response.upload_url
+    s3_key = upload_url_response.s3_key
+    print(f"Upload URL issued (s3_key={s3_key}, "
+          f"max_records={upload_url_response.get('max_records', '?')}).")
+
+    # --- 3. Upload the NDJSON straight to the presigned URL ------------------
+    # A plain HTTP PUT to S3 using the standard library; this does NOT go through
+    # the SDK (the presigned URL already carries its own auth).
+    body = ndjson.encode('utf-8')
+    put_request = urllib.request.Request(
+        upload_url, data=body, method='PUT',
+        headers={'Content-Type': 'application/x-ndjson'})
+    with urllib.request.urlopen(put_request) as put_response:
+        if put_response.status not in (200, 201):
+            raise RuntimeError(f"Upload PUT failed: {put_response.status} {put_response.reason}")
+    print(f"Uploaded {len(orders)} records ({len(body)} bytes).")
+
+    # --- 4. Submit the job --------------------------------------------------
+    # Orders are insert-only; operation defaults to "insert" but is shown for clarity.
+    request = BulkJobRequest(s3_key=s3_key, operation='insert')
+    # request.webhook_url = 'https://example.com/hooks/bulk'  # optional one-shot completion POST
+
+    submit_response = bulk_api.bulk_submit_job(OBJECT_TYPE, request)
+    job = submit_response.bulk_job
+    job_id = job.job_id
+    print(f"Submitted job {job_id} (status={job.status}).")
+
+    # --- 5. Poll until terminal ---------------------------------------------
+    # Bulk endpoints sit behind their own rate-limit bucket, so polling does not
+    # consume your normal REST budget - but still poll politely and bound the loop.
+    for _ in range(20):
+        if job.get('status') in TERMINAL_STATUSES:
+            break
+        time.sleep(3)
+        job = bulk_api.bulk_get_job(OBJECT_TYPE, job_id).bulk_job
+        print(f"  status={job.get('status')} "
+              f"processed={job.get('processed_records', 0)}/{job.get('total_records', '?')}")
+
+    # --- 6. Report ----------------------------------------------------------
+    print(f"\nJob {job_id} finished: {job.get('status')}")
+    print(f"  success={job.get('success_count', 0)} "
+          f"failed={job.get('fail_count', 0)} duplicate={job.get('duplicate_count', 0)}")
+
+    if job.get('fail_count', 0) > 0:
+        print('\nFailed records:')
+        cursor = None
+        while True:
+            kwargs = {'status': 'failed', 'limit': 100}
+            if cursor:
+                kwargs['cursor'] = cursor
+            records_response = bulk_api.bulk_get_job_records(OBJECT_TYPE, job_id, **kwargs)
+            for record in records_response.records:
+                print(f"  line {record.get('line_number')} "
+                      f"[{record.get('merchant_record_id')}] "
+                      f"{record.get('error_code')}: {record.get('error_message')}")
+            cursor = records_response.get('next_cursor')
+            if not cursor:
+                break
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except ApiException as e:
+        # ApiException's __str__ includes the HTTP status and response body.
+        print('Bulk import failed:')
+        print(e)
+        import sys
+        sys.exit(1)

--- a/python/bulk/bulk_upsert_customers.py
+++ b/python/bulk/bulk_upsert_customers.py
@@ -1,0 +1,136 @@
+# Bulk upsert customers - end-to-end lifecycle with operation="upsert".
+#
+# "upsert" creates a customer when none is found and otherwise replaces the
+# existing one (a full-record replace, identical to PUT /rest/v2/customer - a
+# field you omit is cleared, it is not a partial merge). Upsert is customer-only
+# in v1; submitting operation="upsert" to /rest/v2/bulk/order is a 400.
+#
+# Identity resolution per line:
+#   1. The _merchant_record_id marker from a prior landing wins (that customer is updated).
+#   2. No marker -> resolve by the line's email; still no match -> insert.
+# On success each record reports action="inserted" or action="updated".
+#
+# See bulk_import_orders.py for the fully-commented base flow; this sample
+# highlights only what differs for upsert.
+
+import json
+import time
+import urllib.request
+
+from ultracart.apis import BulkApi
+from ultracart.models import BulkJobRequest
+from ultracart.rest import ApiException
+from samples import api_client
+
+OBJECT_TYPE = 'customer'
+
+TERMINAL_STATUSES = {'succeeded', 'partial_success', 'failed', 'cancelled'}
+
+# Each line is what the per-record customer-create endpoint accepts, plus the
+# top-level _merchant_record_id. When email is your natural key, using it as the
+# _merchant_record_id makes the bulk dedupe and UC's email-uniqueness agree.
+# Build plain dicts, not SDK model instances (the marker is not a Customer field).
+customers = [
+    {
+        '_merchant_record_id': 'jane@example.com',
+        'email': 'jane@example.com',
+        'first_name': 'Jane',
+        'last_name': 'Doe',
+        'billing': [{
+            'first_name': 'Jane', 'last_name': 'Doe', 'address1': '123 Main St',
+            'city': 'Austin', 'state_region': 'TX', 'postal_code': '78701',
+            'country_code': 'US', 'default_billing': True
+        }],
+        'tags': ['legacy-import']
+    },
+    {
+        '_merchant_record_id': 'john@example.com',
+        'email': 'john@example.com',
+        'first_name': 'John',
+        'last_name': 'Smith'
+    }
+]
+
+ndjson = '\n'.join(json.dumps(customer, separators=(',', ':')) for customer in customers)
+
+
+def main():
+    bulk_api = BulkApi(api_client())
+
+    upload_url_response = bulk_api.bulk_generate_upload_url(OBJECT_TYPE)
+    upload_url = upload_url_response.upload_url
+    s3_key = upload_url_response.s3_key
+    print(f"Upload URL issued (s3_key={s3_key}).")
+
+    # Plain HTTP PUT of the NDJSON bytes to the presigned URL (not through the SDK).
+    body = ndjson.encode('utf-8')
+    put_request = urllib.request.Request(
+        upload_url, data=body, method='PUT',
+        headers={'Content-Type': 'application/x-ndjson'})
+    with urllib.request.urlopen(put_request) as put_response:
+        if put_response.status not in (200, 201):
+            raise RuntimeError(f"Upload PUT failed: {put_response.status} {put_response.reason}")
+    print(f"Uploaded {len(customers)} customers.")
+
+    # The only submit difference vs. insert: operation = "upsert".
+    request = BulkJobRequest(s3_key=s3_key, operation='upsert')
+
+    submit_response = bulk_api.bulk_submit_job(OBJECT_TYPE, request)
+    job = submit_response.bulk_job
+    job_id = job.job_id
+    print(f"Submitted upsert job {job_id} (operation={job.get('operation')}).")
+
+    for _ in range(20):
+        if job.get('status') in TERMINAL_STATUSES:
+            break
+        time.sleep(3)
+        job = bulk_api.bulk_get_job(OBJECT_TYPE, job_id).bulk_job
+        print(f"  status={job.get('status')} "
+              f"processed={job.get('processed_records', 0)}/{job.get('total_records', '?')}")
+
+    print(f"\nJob {job_id} finished: {job.get('status')}")
+    print(f"  success={job.get('success_count', 0)} "
+          f"failed={job.get('fail_count', 0)} duplicate={job.get('duplicate_count', 0)}")
+
+    # On upsert, each successful record tells you whether it created or replaced a
+    # customer via the "action" field (inserted | updated).
+    print('\nPer-record actions:')
+    cursor = None
+    while True:
+        kwargs = {'status': 'success', 'limit': 100}
+        if cursor:
+            kwargs['cursor'] = cursor
+        records_response = bulk_api.bulk_get_job_records(OBJECT_TYPE, job_id, **kwargs)
+        for record in records_response.records:
+            print(f"  [{record.get('merchant_record_id')}] "
+                  f"{record.get('action')} -> uc_id={record.get('uc_id')}")
+        cursor = records_response.get('next_cursor')
+        if not cursor:
+            break
+
+    if job.get('fail_count', 0) > 0:
+        print("\nFailed records (an email_conflict means the line's email belongs to a "
+              "different customer than the marker resolved to):")
+        cursor = None
+        while True:
+            kwargs = {'status': 'failed', 'limit': 100}
+            if cursor:
+                kwargs['cursor'] = cursor
+            records_response = bulk_api.bulk_get_job_records(OBJECT_TYPE, job_id, **kwargs)
+            for record in records_response.records:
+                print(f"  line {record.get('line_number')} "
+                      f"[{record.get('merchant_record_id')}] "
+                      f"{record.get('error_code')}: {record.get('error_message')}")
+            cursor = records_response.get('next_cursor')
+            if not cursor:
+                break
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except ApiException as e:
+        print('Bulk upsert failed:')
+        print(e)
+        import sys
+        sys.exit(1)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,1 +1,1 @@
-ultracart-rest-sdk==4.1.97
+ultracart-rest-sdk==4.1.109

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'rubocop', group: 'development'
-gem 'ultracart_api', '4.1.97'
+gem 'ultracart_api', '4.1.109'

--- a/ruby/bulk/bulk_import_orders.rb
+++ b/ruby/bulk/bulk_import_orders.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+# Bulk import orders -- end-to-end lifecycle.
+#
+# The bulk API is a throughput multiplier for the per-record REST endpoints: you
+# upload an NDJSON file of records, submit one job, then poll it to completion.
+#
+# Flow demonstrated here:
+#   1. Build an NDJSON payload (one order per line, each with a stable _merchant_record_id).
+#   2. Ask the Bulk API for a presigned S3 upload URL.
+#   3. PUT the NDJSON bytes straight to that URL (this step does NOT go through the SDK).
+#   4. Submit the job. Orders are insert-only; operation defaults to "insert".
+#   5. Poll the job until it reaches a terminal status.
+#   6. Print the counts and list any failed records.
+#
+# For create-or-update semantics, see bulk_upsert_customers.rb (customer upsert).
+
+require 'json'
+require 'net/http'
+require 'uri'
+require 'ultracart_api'
+require_relative '../constants'
+
+OBJECT_TYPE = 'order'
+
+api = UltracartClient::BulkApi.new_using_api_key(Constants::API_KEY, Constants::VERIFY_SSL, Constants::DEBUG_MODE)
+
+# --- 1. Build the NDJSON payload -------------------------------------------
+# Each line is exactly what POST /rest/v2/order accepts, PLUS a top-level
+# _merchant_record_id -- the bulk-surface dedupe key. Use a STABLE value derived
+# from your source system (e.g. the legacy order id), NOT a fresh UUID, so that
+# re-running a fixed file collapses to the original landing instead of re-inserting.
+#
+# NOTE: these are plain Ruby hashes, not SDK model instances. _merchant_record_id
+# is not an SDK model field, and the worker parses each line as raw JSON, so we
+# build the lines by hand rather than through UltracartClient::Order.
+orders = [
+  {
+    _merchant_record_id: 'legacy-order-1029384',
+    merchant_order_id: 'ORD-1029384',
+    creation_dts: '2023-11-14T09:22:00Z',
+    currency_code: 'USD',
+    total: 79.50,
+    customer_profile: { email: 'jane@example.com' },
+    items: [
+      { merchant_item_id: 'WIDGET-RED', quantity: 2, unit_cost: { currency_code: 'USD', value: 35.00 } }
+    ],
+    shipping: {
+      ship_to: {
+        first_name: 'Jane', last_name: 'Doe', address1: '123 Main St',
+        city: 'Austin', state_region: 'TX', postal_code: '78701', country_code: 'US'
+      },
+      shipping_method: 'Standard'
+    }
+  },
+  {
+    _merchant_record_id: 'legacy-order-1029385',
+    merchant_order_id: 'ORD-1029385',
+    creation_dts: '2023-11-15T14:03:00Z',
+    currency_code: 'USD',
+    total: 35.00,
+    customer_profile: { email: 'john@example.com' },
+    items: [
+      { merchant_item_id: 'WIDGET-BLUE', quantity: 1, unit_cost: { currency_code: 'USD', value: 35.00 } }
+    ]
+  }
+]
+
+# NDJSON = one minified JSON object per line, LF-separated. Do NOT wrap the records
+# in a JSON array and do NOT pretty-print -- the worker parses the file line by line.
+ndjson = orders.map(&:to_json).join("\n")
+
+# Terminal job statuses -- poll stops once the job reaches one of these.
+TERMINAL = %w[succeeded partial_success failed cancelled].freeze
+POLL_TRIES = 20
+POLL_SLEEP = 3 # seconds
+
+begin
+  # --- 2. Get a presigned upload URL --------------------------------------
+  upload_url_response = api.bulk_generate_upload_url(OBJECT_TYPE)
+  upload_url = upload_url_response.upload_url
+  s3_key = upload_url_response.s3_key
+  puts "Upload URL issued (s3_key=#{s3_key}, max_records=#{upload_url_response.max_records})."
+
+  # --- 3. Upload the NDJSON straight to the presigned URL ------------------
+  # A plain HTTP PUT to S3 -- this does NOT go through the SDK. The presigned URL
+  # already carries its auth in the query string, so we send only the body.
+  uri = URI(upload_url)
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = (uri.scheme == 'https')
+  put = Net::HTTP::Put.new(uri)
+  put['Content-Type'] = 'application/x-ndjson'
+  put.body = ndjson
+  put_response = http.request(put)
+  unless put_response.is_a?(Net::HTTPSuccess)
+    raise "Upload PUT failed: #{put_response.code} #{put_response.message}"
+  end
+
+  puts "Uploaded #{orders.length} records (#{ndjson.bytesize} bytes)."
+
+  # --- 4. Submit the job --------------------------------------------------
+  request = UltracartClient::BulkJobRequest.new
+  request.s3_key = s3_key
+  request.operation = 'insert' # default for orders; shown here for clarity
+  # request.webhook_url = 'https://example.com/hooks/bulk' # optional one-shot completion POST
+
+  submit_response = api.bulk_submit_job(OBJECT_TYPE, request)
+  job = submit_response.bulk_job
+  job_id = job.job_id
+  puts "Submitted job #{job_id} (status=#{job.status})."
+
+  # --- 5. Poll until terminal ---------------------------------------------
+  # Bulk endpoints sit behind their own rate-limit bucket, so polling does not
+  # consume your normal REST budget -- but still poll politely and bound the loop
+  # so a stuck job can't hang the sample forever.
+  tries = 0
+  while !TERMINAL.include?(job.status) && tries < POLL_TRIES
+    sleep POLL_SLEEP
+    job = api.bulk_get_job(OBJECT_TYPE, job_id).bulk_job
+    puts "  status=#{job.status} processed=#{job.processed_records || 0}/#{job.total_records || '?'}"
+    tries += 1
+  end
+
+  # --- 6. Report ----------------------------------------------------------
+  puts "\nJob #{job_id} finished: #{job.status}"
+  puts "  success=#{job.success_count} failed=#{job.fail_count} duplicate=#{job.duplicate_count}"
+
+  if job.fail_count.to_i.positive?
+    puts "\nFailed records:"
+    cursor = nil
+    loop do
+      opts = { status: 'failed', limit: 100 }
+      opts[:cursor] = cursor if cursor
+      records_response = api.bulk_get_job_records(OBJECT_TYPE, job_id, opts)
+      records_response.records.each do |record|
+        puts "  line #{record.line_number} [#{record.merchant_record_id}] #{record.error_code}: #{record.error_message}"
+      end
+      cursor = records_response.next_cursor
+      break unless cursor
+    end
+  end
+rescue UltracartClient::ApiError => e
+  # SDK errors carry the HTTP response body, which holds the server-side detail.
+  puts "Bulk import failed: #{e.response_body || e.message}"
+end

--- a/ruby/bulk/bulk_upsert_customers.rb
+++ b/ruby/bulk/bulk_upsert_customers.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+# Bulk upsert customers -- end-to-end lifecycle with operation="upsert".
+#
+# "upsert" creates a customer when none is found and otherwise replaces the
+# existing one (a full-record replace, identical to PUT /rest/v2/customer -- a
+# field you omit is cleared, it is not a partial merge). Upsert is customer-only
+# in v1; submitting operation="upsert" to /rest/v2/bulk/order is a 400.
+#
+# Identity resolution per line:
+#   1. The _merchant_record_id marker from a prior landing wins (that customer is updated).
+#   2. No marker -> resolve by the line's email; still no match -> insert.
+# On success each record reports action="inserted" or action="updated".
+#
+# See bulk_import_orders.rb for the fully-commented base flow; this sample
+# highlights only what differs for upsert.
+
+require 'json'
+require 'net/http'
+require 'uri'
+require 'ultracart_api'
+require_relative '../constants'
+
+OBJECT_TYPE = 'customer'
+
+api = UltracartClient::BulkApi.new_using_api_key(Constants::API_KEY, Constants::VERIFY_SSL, Constants::DEBUG_MODE)
+
+# Each line is what the per-record customer-create endpoint accepts, plus the
+# top-level _merchant_record_id. When email is your natural key, using it as the
+# _merchant_record_id makes the bulk dedupe and UC's email-uniqueness agree.
+# These are plain Ruby hashes (raw NDJSON), not UltracartClient::Customer models.
+customers = [
+  {
+    _merchant_record_id: 'jane@example.com',
+    email: 'jane@example.com',
+    first_name: 'Jane',
+    last_name: 'Doe',
+    billing: [{
+      first_name: 'Jane', last_name: 'Doe', address1: '123 Main St',
+      city: 'Austin', state_region: 'TX', postal_code: '78701', country_code: 'US', default_billing: true
+    }],
+    tags: ['legacy-import']
+  },
+  {
+    _merchant_record_id: 'john@example.com',
+    email: 'john@example.com',
+    first_name: 'John',
+    last_name: 'Smith'
+  }
+]
+
+ndjson = customers.map(&:to_json).join("\n")
+
+TERMINAL = %w[succeeded partial_success failed cancelled].freeze
+POLL_TRIES = 20
+POLL_SLEEP = 3 # seconds
+
+begin
+  upload_url_response = api.bulk_generate_upload_url(OBJECT_TYPE)
+  upload_url = upload_url_response.upload_url
+  s3_key = upload_url_response.s3_key
+  puts "Upload URL issued (s3_key=#{s3_key})."
+
+  # Raw HTTP PUT to the presigned S3 URL -- does NOT go through the SDK.
+  uri = URI(upload_url)
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = (uri.scheme == 'https')
+  put = Net::HTTP::Put.new(uri)
+  put['Content-Type'] = 'application/x-ndjson'
+  put.body = ndjson
+  put_response = http.request(put)
+  unless put_response.is_a?(Net::HTTPSuccess)
+    raise "Upload PUT failed: #{put_response.code} #{put_response.message}"
+  end
+
+  puts "Uploaded #{customers.length} customers."
+
+  # The only submit difference vs. insert: operation = "upsert".
+  request = UltracartClient::BulkJobRequest.new
+  request.s3_key = s3_key
+  request.operation = 'upsert'
+
+  submit_response = api.bulk_submit_job(OBJECT_TYPE, request)
+  job = submit_response.bulk_job
+  job_id = job.job_id
+  puts "Submitted upsert job #{job_id} (operation=#{job.operation})."
+
+  tries = 0
+  while !TERMINAL.include?(job.status) && tries < POLL_TRIES
+    sleep POLL_SLEEP
+    job = api.bulk_get_job(OBJECT_TYPE, job_id).bulk_job
+    puts "  status=#{job.status} processed=#{job.processed_records || 0}/#{job.total_records || '?'}"
+    tries += 1
+  end
+
+  puts "\nJob #{job_id} finished: #{job.status}"
+  puts "  success=#{job.success_count} failed=#{job.fail_count} duplicate=#{job.duplicate_count}"
+
+  # On upsert, each successful record tells you whether it created or replaced a
+  # customer via the "action" field (inserted | updated).
+  puts "\nPer-record actions:"
+  cursor = nil
+  loop do
+    opts = { status: 'success', limit: 100 }
+    opts[:cursor] = cursor if cursor
+    records_response = api.bulk_get_job_records(OBJECT_TYPE, job_id, opts)
+    records_response.records.each do |record|
+      puts "  [#{record.merchant_record_id}] #{record.action} -> uc_id=#{record.uc_id}"
+    end
+    cursor = records_response.next_cursor
+    break unless cursor
+  end
+
+  if job.fail_count.to_i.positive?
+    puts "\nFailed records (an email_conflict means the line's email belongs to a different customer than the marker resolved to):"
+    cursor = nil
+    loop do
+      opts = { status: 'failed', limit: 100 }
+      opts[:cursor] = cursor if cursor
+      records_response = api.bulk_get_job_records(OBJECT_TYPE, job_id, opts)
+      records_response.records.each do |record|
+        puts "  line #{record.line_number} [#{record.merchant_record_id}] #{record.error_code}: #{record.error_message}"
+      end
+      cursor = records_response.next_cursor
+      break unless cursor
+    end
+  end
+rescue UltracartClient::ApiError => e
+  puts "Bulk upsert failed: #{e.response_body || e.message}"
+end

--- a/typescript/api.ts
+++ b/typescript/api.ts
@@ -1,4 +1,5 @@
 import {
+    BulkApi,
     CouponApi,
     GiftCertificateApi,
     OrderApi,
@@ -21,6 +22,7 @@ let apiKey = 'fbfa455fa3bc2e019e456ffe06200100122d966fc28870019e456ffe08200100';
 // export const orderApi = new OrderApi(new Configuration({apiVersion: '2017-03-01', apiKey: apiKey, fetchApi: fetch }));
 
 export const autoOrderApi = new AutoOrderApi(new Configuration({apiVersion: '2017-03-01', apiKey: apiKey }));
+export const bulkApi = new BulkApi(new Configuration({apiVersion: '2017-03-01', apiKey: apiKey }));
 export const channelPartnerApi = new ChannelPartnerApi(new Configuration({apiVersion: '2017-03-01', apiKey: apiKey }));
 export const checkoutApi = new CheckoutApi(new Configuration({apiVersion: '2017-03-01', apiKey: apiKey }));
 export const couponApi = new CouponApi(new Configuration({apiVersion: '2017-03-01', apiKey: apiKey }));

--- a/typescript/bulk/BulkImportOrders.ts
+++ b/typescript/bulk/BulkImportOrders.ts
@@ -1,0 +1,189 @@
+// Bulk import orders — end-to-end lifecycle.
+//
+// The bulk API is a throughput multiplier for the per-record REST endpoints: you
+// upload an NDJSON file of records, submit one job, then poll it to completion.
+//
+// Flow demonstrated here:
+//   1. Build an NDJSON payload (one order per line, each with a stable _merchant_record_id).
+//   2. Ask the Bulk API for a presigned S3 upload URL.
+//   3. PUT the NDJSON bytes straight to that URL (this step does NOT go through the SDK).
+//   4. Submit the job. Orders are insert-only; operation defaults to "insert".
+//   5. Poll the job until it reaches a terminal status.
+//   6. Print the counts and list any failed records.
+//
+// For create-or-update semantics, see BulkUpsertCustomers.ts (customer upsert).
+
+import * as https from 'https';
+import { URL } from 'url';
+import { bulkApi } from '../api';
+import {
+    BulkJob,
+    BulkJobRequest,
+    BulkJobRequestOperationEnum,
+    BulkRecordsResponse,
+} from 'ultracart_rest_api_v2_typescript';
+
+// ReSharper disable once ClassNeverInstantiated.Global
+export class BulkImportOrders {
+    private static readonly OBJECT_TYPE = 'order';
+
+    // Terminal job statuses — stop polling once the job reports one of these.
+    private static readonly TERMINAL = ['succeeded', 'partial_success', 'failed', 'cancelled'];
+
+    // Bound the poll so a stuck job can never hang the sample.
+    private static readonly MAX_POLLS = 20;
+    private static readonly POLL_INTERVAL_MS = 3000;
+
+    public static async execute(): Promise<void> {
+        // --- 1. Build the NDJSON payload ------------------------------------
+        // Each line is exactly what POST /rest/v2/order accepts, PLUS a top-level
+        // _merchant_record_id — the bulk-surface dedupe key. Use a STABLE value
+        // derived from your source system (e.g. the legacy order id), NOT a fresh
+        // UUID, so that re-running a fixed file collapses to the original landing
+        // instead of re-inserting. These are PLAIN objects, not SDK model
+        // instances, because _merchant_record_id is not an SDK model field.
+        const orders: Array<Record<string, unknown>> = [
+            {
+                _merchant_record_id: 'legacy-order-1029384',
+                merchant_order_id: 'ORD-1029384',
+                creation_dts: '2023-11-14T09:22:00Z',
+                currency_code: 'USD',
+                total: 79.50,
+                customer_profile: { email: 'jane@example.com' },
+                items: [
+                    { merchant_item_id: 'WIDGET-RED', quantity: 2, unit_cost: { currency_code: 'USD', value: 35.00 } },
+                ],
+                shipping: {
+                    ship_to: {
+                        first_name: 'Jane', last_name: 'Doe', address1: '123 Main St',
+                        city: 'Austin', state_region: 'TX', postal_code: '78701', country_code: 'US',
+                    },
+                    shipping_method: 'Standard',
+                },
+            },
+            {
+                _merchant_record_id: 'legacy-order-1029385',
+                merchant_order_id: 'ORD-1029385',
+                creation_dts: '2023-11-15T14:03:00Z',
+                currency_code: 'USD',
+                total: 35.00,
+                customer_profile: { email: 'john@example.com' },
+                items: [
+                    { merchant_item_id: 'WIDGET-BLUE', quantity: 1, unit_cost: { currency_code: 'USD', value: 35.00 } },
+                ],
+            },
+        ];
+
+        // NDJSON = one minified JSON object per line, LF-separated. Do NOT wrap the
+        // records in a JSON array and do NOT pretty-print — the worker parses the
+        // file line by line.
+        const ndjson = orders.map((order) => JSON.stringify(order)).join('\n');
+
+        // --- 2. Get a presigned upload URL ----------------------------------
+        const uploadUrlResponse = await bulkApi.bulkGenerateUploadUrl({ object: BulkImportOrders.OBJECT_TYPE });
+        const uploadUrl = uploadUrlResponse.upload_url;
+        const s3Key = uploadUrlResponse.s3_key;
+        if (!uploadUrl || !s3Key) {
+            throw new Error('Bulk upload-url response did not include upload_url / s3_key.');
+        }
+        console.log(`Upload URL issued (s3_key=${s3Key}, max_records=${uploadUrlResponse.max_records}).`);
+
+        // --- 3. Upload the NDJSON straight to the presigned URL -------------
+        // A plain HTTP PUT to S3 — this does NOT go through the SDK.
+        await BulkImportOrders.putBytes(uploadUrl, ndjson);
+        console.log(`Uploaded ${orders.length} records (${Buffer.byteLength(ndjson)} bytes).`);
+
+        // --- 4. Submit the job ----------------------------------------------
+        const bulkJobRequest: BulkJobRequest = {
+            s3_key: s3Key,
+            operation: BulkJobRequestOperationEnum.Insert, // default for orders; shown for clarity
+            // webhook_url: 'https://example.com/hooks/bulk', // optional one-shot completion POST
+        };
+
+        const submitResponse = await bulkApi.bulkSubmitJob({
+            object: BulkImportOrders.OBJECT_TYPE,
+            bulkJob: bulkJobRequest,
+        });
+        let job: BulkJob = submitResponse.bulk_job ?? {};
+        const jobId = job.job_id;
+        if (!jobId) {
+            throw new Error('Bulk submit response did not include a job id.');
+        }
+        console.log(`Submitted job ${jobId} (status=${job.status}).`);
+
+        // --- 5. Poll until terminal -----------------------------------------
+        // Bulk endpoints sit behind their own rate-limit bucket, so polling does
+        // not consume your normal REST budget — but still poll politely, and bound
+        // the loop so it can never hang.
+        let polls = 0;
+        while (!BulkImportOrders.TERMINAL.includes(job.status ?? '') && polls < BulkImportOrders.MAX_POLLS) {
+            await BulkImportOrders.sleep(BulkImportOrders.POLL_INTERVAL_MS);
+            const jobResponse = await bulkApi.bulkGetJob({ object: BulkImportOrders.OBJECT_TYPE, jobId });
+            job = jobResponse.bulk_job ?? job;
+            polls++;
+            console.log(`  status=${job.status} processed=${job.processed_records ?? 0}/${job.total_records ?? '?'}`);
+        }
+
+        // --- 6. Report ------------------------------------------------------
+        console.log(`\nJob ${jobId} finished: ${job.status}`);
+        console.log(`  success=${job.success_count} failed=${job.fail_count} duplicate=${job.duplicate_count}`);
+
+        if ((job.fail_count ?? 0) > 0) {
+            console.log('\nFailed records:');
+            let cursor: string | undefined;
+            do {
+                const recordsResponse: BulkRecordsResponse = await bulkApi.bulkGetJobRecords({
+                    object: BulkImportOrders.OBJECT_TYPE,
+                    jobId,
+                    status: 'failed',
+                    limit: 100,
+                    cursor,
+                });
+                for (const record of recordsResponse.records ?? []) {
+                    console.log(`  line ${record.line_number} [${record.merchant_record_id}] ${record.error_code}: ${record.error_message}`);
+                }
+                cursor = recordsResponse.next_cursor;
+            } while (cursor);
+        }
+    }
+
+    private static sleep(ms: number): Promise<void> {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+    }
+
+    /**
+     * Raw HTTP PUT of the NDJSON bytes to the presigned S3 URL. This step does NOT
+     * go through the SDK — it is a direct upload to S3. Uses Node's built-in https
+     * client so the sample type-checks with only @types/node (no DOM lib required).
+     */
+    private static putBytes(uploadUrl: string, body: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const url = new URL(uploadUrl);
+            const payload = Buffer.from(body, 'utf-8');
+            const req = https.request(
+                {
+                    method: 'PUT',
+                    hostname: url.hostname,
+                    port: url.port || 443,
+                    path: `${url.pathname}${url.search}`,
+                    headers: {
+                        'Content-Type': 'application/x-ndjson',
+                        'Content-Length': payload.length,
+                    },
+                },
+                (res) => {
+                    const status = res.statusCode ?? 0;
+                    res.resume(); // drain so the socket can close
+                    if (status >= 200 && status < 300) {
+                        resolve();
+                    } else {
+                        reject(new Error(`Upload PUT failed: ${status} ${res.statusMessage}`));
+                    }
+                },
+            );
+            req.on('error', reject);
+            req.write(payload);
+            req.end();
+        });
+    }
+}

--- a/typescript/bulk/BulkUpsertCustomers.ts
+++ b/typescript/bulk/BulkUpsertCustomers.ts
@@ -1,0 +1,177 @@
+// Bulk upsert customers — end-to-end lifecycle with operation="upsert".
+//
+// "upsert" creates a customer when none is found and otherwise replaces the
+// existing one (a full-record replace, identical to PUT /rest/v2/customer — a
+// field you omit is cleared, it is not a partial merge). Upsert is customer-only
+// in v1; submitting operation="upsert" to /rest/v2/bulk/order is a 400.
+//
+// Identity resolution per line:
+//   1. The _merchant_record_id marker from a prior landing wins (that customer is updated).
+//   2. No marker -> resolve by the line's email; still no match -> insert.
+// On success each record reports action="inserted" or action="updated".
+//
+// See BulkImportOrders.ts for the fully-commented base flow; this sample
+// highlights only what differs for upsert.
+
+import * as https from 'https';
+import { URL } from 'url';
+import { bulkApi } from '../api';
+import {
+    BulkJob,
+    BulkJobRequest,
+    BulkJobRequestOperationEnum,
+    BulkRecordsResponse,
+} from 'ultracart_rest_api_v2_typescript';
+
+// ReSharper disable once ClassNeverInstantiated.Global
+export class BulkUpsertCustomers {
+    private static readonly OBJECT_TYPE = 'customer';
+
+    private static readonly TERMINAL = ['succeeded', 'partial_success', 'failed', 'cancelled'];
+    private static readonly MAX_POLLS = 20;
+    private static readonly POLL_INTERVAL_MS = 3000;
+
+    public static async execute(): Promise<void> {
+        // Each line is what the per-record customer-create endpoint accepts, plus
+        // the top-level _merchant_record_id. When email is your natural key, using
+        // it as the _merchant_record_id makes the bulk dedupe and UC's
+        // email-uniqueness agree. These are PLAIN objects, not SDK model instances.
+        const customers: Array<Record<string, unknown>> = [
+            {
+                _merchant_record_id: 'jane@example.com',
+                email: 'jane@example.com',
+                first_name: 'Jane',
+                last_name: 'Doe',
+                billing: [{
+                    first_name: 'Jane', last_name: 'Doe', address1: '123 Main St',
+                    city: 'Austin', state_region: 'TX', postal_code: '78701', country_code: 'US', default_billing: true,
+                }],
+                tags: ['legacy-import'],
+            },
+            {
+                _merchant_record_id: 'john@example.com',
+                email: 'john@example.com',
+                first_name: 'John',
+                last_name: 'Smith',
+            },
+        ];
+
+        const ndjson = customers.map((customer) => JSON.stringify(customer)).join('\n');
+
+        const uploadUrlResponse = await bulkApi.bulkGenerateUploadUrl({ object: BulkUpsertCustomers.OBJECT_TYPE });
+        const uploadUrl = uploadUrlResponse.upload_url;
+        const s3Key = uploadUrlResponse.s3_key;
+        if (!uploadUrl || !s3Key) {
+            throw new Error('Bulk upload-url response did not include upload_url / s3_key.');
+        }
+        console.log(`Upload URL issued (s3_key=${s3Key}).`);
+
+        await BulkUpsertCustomers.putBytes(uploadUrl, ndjson);
+        console.log(`Uploaded ${customers.length} customers.`);
+
+        // The only submit difference vs. insert: operation = "upsert".
+        const bulkJobRequest: BulkJobRequest = {
+            s3_key: s3Key,
+            operation: BulkJobRequestOperationEnum.Upsert,
+        };
+
+        const submitResponse = await bulkApi.bulkSubmitJob({
+            object: BulkUpsertCustomers.OBJECT_TYPE,
+            bulkJob: bulkJobRequest,
+        });
+        let job: BulkJob = submitResponse.bulk_job ?? {};
+        const jobId = job.job_id;
+        if (!jobId) {
+            throw new Error('Bulk submit response did not include a job id.');
+        }
+        console.log(`Submitted upsert job ${jobId} (operation=${job.operation}).`);
+
+        let polls = 0;
+        while (!BulkUpsertCustomers.TERMINAL.includes(job.status ?? '') && polls < BulkUpsertCustomers.MAX_POLLS) {
+            await BulkUpsertCustomers.sleep(BulkUpsertCustomers.POLL_INTERVAL_MS);
+            const jobResponse = await bulkApi.bulkGetJob({ object: BulkUpsertCustomers.OBJECT_TYPE, jobId });
+            job = jobResponse.bulk_job ?? job;
+            polls++;
+            console.log(`  status=${job.status} processed=${job.processed_records ?? 0}/${job.total_records ?? '?'}`);
+        }
+
+        console.log(`\nJob ${jobId} finished: ${job.status}`);
+        console.log(`  success=${job.success_count} failed=${job.fail_count} duplicate=${job.duplicate_count}`);
+
+        // On upsert, each successful record tells you whether it created or replaced
+        // a customer via the "action" field (inserted | updated).
+        console.log('\nPer-record actions:');
+        let cursor: string | undefined;
+        do {
+            const recordsResponse: BulkRecordsResponse = await bulkApi.bulkGetJobRecords({
+                object: BulkUpsertCustomers.OBJECT_TYPE,
+                jobId,
+                status: 'success',
+                limit: 100,
+                cursor,
+            });
+            for (const record of recordsResponse.records ?? []) {
+                console.log(`  [${record.merchant_record_id}] ${record.action} -> uc_id=${record.uc_id}`);
+            }
+            cursor = recordsResponse.next_cursor;
+        } while (cursor);
+
+        if ((job.fail_count ?? 0) > 0) {
+            console.log('\nFailed records (an email_conflict means the line\'s email belongs to a different customer than the marker resolved to):');
+            cursor = undefined;
+            do {
+                const recordsResponse: BulkRecordsResponse = await bulkApi.bulkGetJobRecords({
+                    object: BulkUpsertCustomers.OBJECT_TYPE,
+                    jobId,
+                    status: 'failed',
+                    limit: 100,
+                    cursor,
+                });
+                for (const record of recordsResponse.records ?? []) {
+                    console.log(`  line ${record.line_number} [${record.merchant_record_id}] ${record.error_code}: ${record.error_message}`);
+                }
+                cursor = recordsResponse.next_cursor;
+            } while (cursor);
+        }
+    }
+
+    private static sleep(ms: number): Promise<void> {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+    }
+
+    /**
+     * Raw HTTP PUT of the NDJSON bytes to the presigned S3 URL. This step does NOT
+     * go through the SDK — it is a direct upload to S3. Uses Node's built-in https
+     * client so the sample type-checks with only @types/node (no DOM lib required).
+     */
+    private static putBytes(uploadUrl: string, body: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const url = new URL(uploadUrl);
+            const payload = Buffer.from(body, 'utf-8');
+            const req = https.request(
+                {
+                    method: 'PUT',
+                    hostname: url.hostname,
+                    port: url.port || 443,
+                    path: `${url.pathname}${url.search}`,
+                    headers: {
+                        'Content-Type': 'application/x-ndjson',
+                        'Content-Length': payload.length,
+                    },
+                },
+                (res) => {
+                    const status = res.statusCode ?? 0;
+                    res.resume(); // drain so the socket can close
+                    if (status >= 200 && status < 300) {
+                        resolve();
+                    } else {
+                        reject(new Error(`Upload PUT failed: ${status} ${res.statusMessage}`));
+                    }
+                },
+            );
+            req.on('error', reject);
+            req.write(payload);
+            req.end();
+        });
+    }
+}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -7,7 +7,7 @@
     "@types/node": "^16.18.126",
     "luxon": "2.5.2",
     "typescript": "^4.9.5",
-    "ultracart_rest_api_v2_typescript": "4.1.97",
+    "ultracart_rest_api_v2_typescript": "4.1.109",
     "uuid": "^11.1.0"
   },
   "author": "UltraCart",


### PR DESCRIPTION
## Summary

Adds end-to-end samples for the new **Bulk Jobs API** (`/rest/v2/bulk/{object}`)
in all 8 SDK languages, bumps each SDK pin to **4.1.109** (the first release that
ships the bulk surface), and includes the one fix that bump requires.

The Bulk API is a throughput multiplier for the per-record endpoints: upload an
NDJSON file, submit one async job, and poll it to completion — built for large
migrations that would otherwise hit per-request rate limits.

## What the samples show

Two samples per language, each walking the full async lifecycle
(build NDJSON → request a presigned S3 URL → PUT the payload → submit → poll to a
terminal status → read per-record results):

- **`BulkImportOrders`** — bulk **order insert**; lists any failed records.
- **`BulkUpsertCustomers`** — bulk **customer upsert** (`operation=upsert`); prints
  the per-record `action` (`inserted`/`updated`) and surfaces `email_conflict`
  failures.

New files (2 each): `javascript/bulk/`, `typescript/bulk/`, `python/bulk/`,
`php/bulk/`, `ruby/bulk/`, `java/src/bulk/`, `csharp/bulk/`, `curl/bulk/`.

## SDK version bump → 4.1.109

Manifests updated: `javascript/package.json` (+`package-lock.json`),
`typescript/package.json`, `python/requirements.txt`, `php/composer.json`,
`ruby/Gemfile`, `java/pom.xml`, `csharp/packages.config` + `SDKSample.csproj`.

The bulk API is wired into the shared client bootstrap where one exists
(`javascript/api.js`, `typescript/api.ts`, `php/samples.php`, `csharp/Samples.cs`);
Python/Ruby/Java construct it inline per sample, matching those languages' existing
samples. No secrets — all samples reuse the existing shared dev key.

## Required fix (from the SDK bump)

`java/src/webhook/GetWebhookLogSummaries.java` — `WebhookApi.getWebhookLogSummaries`
grew from 4 to 13 parameters in 4.1.109, so the existing 4-arg call no longer
compiled. Updated to the new signature (original `webhookOid`/`limit`/`offset`/`since`
plus `null` for the nine new optional filters). The full `java` project now compiles
clean (`mvn compile` → BUILD SUCCESS).

## Validation

- **JavaScript** — run **end-to-end against the DEMO merchant**: customer-upsert job
  succeeded, records created with `action=inserted`, verified via the records endpoint.
- **Java, C#** — compiled against the real published 4.1.109 SDK.
- **TypeScript** — typechecked against the real 4.1.109 typings (0 errors).
- **Python, Ruby, PHP** — validated against the real published 4.1.109 package
  (imports, method signatures, model accessors) plus language syntax checks.
- **curl** — raw HTTP docs (no SDK); NDJSON payloads validated as JSON.

Each SDK-based sample was written against the *actual* generated surface, which caught
several details that differ from the naming convention (e.g. enum-typed
`operation`/`status`/`action` in Java/C#, the TypeScript request-param shape).

## Notes for reviewers

- These samples require **SDK 4.1.109**. To run locally, refresh deps first:
  `npm install` / `composer update` / `bundle update ultracart_api` /
  `pip install -r requirements.txt`. Only `javascript/package-lock.json` is versioned
  (already at 4.1.109); other lockfiles aren't tracked, per repo convention.
- curl response bodies are illustrative (representative DEMO-style values), matching
  how the other curl samples document expected responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
