### PR TITLE
Add order payment_transaction_filters search samples across 8 languages (SDK 4.1.119)

### DIFF
--- a/csharp/SDKSample.csproj
+++ b/csharp/SDKSample.csproj
@@ -362,6 +362,7 @@
     <Compile Include="order\Replacement.cs" />
     <Compile Include="order\ResendReceipt.cs" />
     <Compile Include="order\ResendShipmentConfirmation.cs" />
+    <Compile Include="order\SearchOrdersByPaymentTransaction.cs" />
     <Compile Include="order\UnblockRefundOnOrder.cs" />
     <Compile Include="order\UpdateAccountsReceivableRetryConfig.cs" />
     <Compile Include="order\UpdateOrder.cs" />
@@ -623,8 +624,8 @@
     <Compile Include="workflow\UpdateWorkflowTask.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="com.ultracart.admin.v2, Version=4.1.109.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\com.ultracart.admin.v2.4.1.109\lib\net48\com.ultracart.admin.v2.dll</HintPath>
+    <Reference Include="com.ultracart.admin.v2, Version=4.1.119.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\com.ultracart.admin.v2.4.1.119\lib\net48\com.ultracart.admin.v2.dll</HintPath>
     </Reference>
     <Reference Include="JsonSubTypes, Version=1.7.0.0, Culture=neutral, PublicKeyToken=ee75fc290dbc1176">
       <HintPath>packages\JsonSubTypes.1.7.0\lib\net40\JsonSubTypes.dll</HintPath>

--- a/csharp/order/SearchOrdersByPaymentTransaction.cs
+++ b/csharp/order/SearchOrdersByPaymentTransaction.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using com.ultracart.admin.v2.Api;
+using com.ultracart.admin.v2.Model;
+
+namespace SdkSample.order
+{
+    public class SearchOrdersByPaymentTransaction
+    {
+        /*
+         * Search orders by the key/value pairs recorded on a payment transaction.
+         *
+         * Each payment transaction stores the gateway's response as a set of name/value detail pairs
+         * (payment.transactions[].details[], e.g. authcode, transactionid, rotatingTransactionGatewayCode).
+         * The payment_transaction_filters field on the order query matches against those pairs, letting you
+         * reverse-lookup an order from a gateway/processor transaction id, or reconcile a chargeback.
+         *
+         * Rules enforced by the API:
+         *   - query_target MUST be "cache" (ElasticSearch); the database path cannot search transaction details.
+         *   - Each filter value is REQUIRED and matched EXACTLY (no wildcards).
+         *   - A filter name is OPTIONAL; omit it to match the value across any detail name.
+         *   - Multiple filters are AND-ed against the SAME transaction (the rotating gateway is just another pair).
+         *   - At most 10 filters are allowed.
+         *
+         * The example values below are illustrative - substitute the transaction id / auth code / amount / dates
+         * from your own gateway or chargeback record.
+         */
+        public static void Execute()
+        {
+            OrderApi orderApi = new OrderApi(Constants.ApiKey);
+            string expansion = "summary,payment,payment.transaction";
+
+            // Search #1 - reverse-lookup an order from a gateway transaction id.
+            // The two filters are AND-ed against the SAME transaction: the rotating gateway code AND the gateway transaction id.
+            OrderQuery query1 = new OrderQuery
+            {
+                QueryTarget = OrderQuery.QueryTargetEnum.Cache, // transaction-detail search requires the cache
+                PaymentTransactionFilters = new List<OrderQueryPaymentTransactionFilter>
+                {
+                    new OrderQueryPaymentTransactionFilter(name: "rotatingTransactionGatewayCode", value: "NMI"),
+                    new OrderQueryPaymentTransactionFilter(name: "transactionid", value: "12244247793")
+                    // Tip: to match a value under ANY detail name, omit name: new OrderQueryPaymentTransactionFilter(value: "12244247793")
+                }
+            };
+            OrdersResponse response1 = orderApi.GetOrdersByQuery(query1, 200, 0, null, expansion);
+            PrintMatches("Search by transaction id", response1);
+
+            // Search #2 - reconcile a chargeback when you do not have the order id.
+            // The auth code from the chargeback file is stored as the "authcode" detail; combine it with the
+            // transaction amount (total) and a payment date window to uniquely identify the order.
+            OrderQuery query2 = new OrderQuery
+            {
+                QueryTarget = OrderQuery.QueryTargetEnum.Cache,
+                PaymentTransactionFilters = new List<OrderQueryPaymentTransactionFilter>
+                {
+                    new OrderQueryPaymentTransactionFilter(name: "authcode", value: "100304")
+                },
+                Total = 77.00m,
+                PaymentDateBegin = "2026-06-29T00:00:00+00:00",
+                PaymentDateEnd = "2026-07-01T00:00:00+00:00"
+            };
+            OrdersResponse response2 = orderApi.GetOrdersByQuery(query2, 200, 0, null, expansion);
+            PrintMatches("Chargeback reconciliation", response2);
+        }
+
+        private static void PrintMatches(string label, OrdersResponse response)
+        {
+            List<Order> orders = response.Orders ?? new List<Order>();
+            Console.WriteLine($"{label}: {orders.Count} order(s) matched");
+            foreach (Order order in orders)
+            {
+                Console.WriteLine($"  {order.OrderId}");
+            }
+        }
+    }
+}

--- a/csharp/packages.config
+++ b/csharp/packages.config
@@ -16,5 +16,5 @@
   <package id="System.Text.Json" version="9.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
-  <package id="com.ultracart.admin.v2" version="4.1.109" targetFramework="net48" />
+  <package id="com.ultracart.admin.v2" version="4.1.119" targetFramework="net48" />
 </packages>

--- a/curl/order/searchOrdersByPaymentTransaction.curl
+++ b/curl/order/searchOrdersByPaymentTransaction.curl
@@ -1,0 +1,88 @@
+**Search orders by the key/value pairs recorded on a payment transaction.**
+
+The `payment_transaction_filters` field matches against the detail name/value pairs stored on each payment
+transaction (`payment.transactions[].details[]`), letting you reverse-lookup an order from a gateway/processor
+transaction id, or reconcile a chargeback. Rules: `query_target` must be `cache`; each filter `value` is required
+and matched exactly (no wildcards); `name` is optional (omit to match the value across any detail name); multiple
+filters are AND-ed against the same transaction; at most 10 filters. The example values below are illustrative.
+
+**Request \[[Create API Key](https://ultracart.atlassian.net/wiki/spaces/ucdoc/pages/38688545/API+Simple+Key)\]**
+```bash
+curl -X POST "https://secure.ultracart.com/rest/v2/order/orders/query\\ \
+?_limit=10&_offset=0&_expand=summary%2Cpayment%2Cpayment.transaction" \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
+  -H "X-UltraCart-Api-Version: 2017-03-01" \
+  -H "x-ultracart-simple-key: <YOUR_ULTRACART_SIMPLE_KEY>" \
+  -d $'{
+    "query_target": "cache",
+    "payment_transaction_filters": [
+        {"name": "rotatingTransactionGatewayCode", "value": "NMI"},
+        {"name": "transactionid", "value": "12244247793"}
+    ]
+}'
+```
+
+**Response Headers**
+```html
+Status: 200 OK
+X-UltraCart-Request-Id: 00234A2DB61DBC0199BFED658A80011
+Content-Type: application/json; charset=UTF-8
+Transfer-Encoding: chunked
+```
+
+**Response Body**
+```json
+{
+    "orders": [
+        {
+            "merchant_id": "DEMO",
+            "order_id": "DEMO-0009104390",
+            "current_stage": "Completed Order",
+            "payment": {
+                "payment_method": "Credit Card",
+                "payment_status": "Processed",
+                "payment_dts": "2026-06-30T02:40:01-04:00",
+                "transactions": [
+                    {
+                        "transaction_gateway": "rotating",
+                        "transaction_timestamp": "2026-06-30T02:40:01-04:00",
+                        "successful": true,
+                        "details": [
+                            {"name": "authcode", "value": "100304"},
+                            {"name": "avsresponse", "value": "Y"},
+                            {"name": "orderid", "value": "DEMO-0009104390"},
+                            {"name": "response", "value": "1"},
+                            {"name": "response_code", "value": "100"},
+                            {"name": "responsetext", "value": "Approved"},
+                            {"name": "rotatingTransactionGatewayCode", "value": "NMI"},
+                            {"name": "rotatingTransactionGatewayName", "value": "Network Merchants Gateway"},
+                            {"name": "transactionid", "value": "12244247793"},
+                            {"name": "type", "value": "sale"}
+                        ]
+                    }
+                ]
+            },
+            "summary": {
+                "total": {
+                    "value": 77.00,
+                    "localized": 77.00,
+                    "localized_formatted": "$77.00"
+                }
+            }
+        }
+    ],
+    "success": true,
+    "metadata": {
+        "result_set": {
+            "count": 1,
+            "offset": 0,
+            "limit": 10,
+            "more": false,
+            "next_offset": 0,
+            "total_records": 1
+        },
+        "payload_name": "orders"
+    }
+}
+```

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.ultracart</groupId>
             <artifactId>rest-sdk</artifactId>
-            <version>4.1.109</version>
+            <version>4.1.119</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/java/src/order/SearchOrdersByPaymentTransaction.java
+++ b/java/src/order/SearchOrdersByPaymentTransaction.java
@@ -1,0 +1,81 @@
+package order;
+
+import com.ultracart.admin.v2.OrderApi;
+import com.ultracart.admin.v2.models.Order;
+import com.ultracart.admin.v2.models.OrderQuery;
+import com.ultracart.admin.v2.models.OrderQueryPaymentTransactionFilter;
+import com.ultracart.admin.v2.models.OrdersResponse;
+import com.ultracart.admin.v2.util.ApiException;
+import common.Constants;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class SearchOrdersByPaymentTransaction {
+    /*
+     * Search orders by the key/value pairs recorded on a payment transaction.
+     *
+     * Each payment transaction stores the gateway's response as a set of name/value detail pairs
+     * (payment.transactions[].details[], e.g. authcode, transactionid, rotatingTransactionGatewayCode).
+     * The payment_transaction_filters field on the order query matches against those pairs, letting you
+     * reverse-lookup an order from a gateway/processor transaction id, or reconcile a chargeback.
+     *
+     * Rules enforced by the API:
+     *   - query_target MUST be "cache" (ElasticSearch); the database path cannot search transaction details.
+     *   - Each filter value is REQUIRED and matched EXACTLY (no wildcards).
+     *   - A filter name is OPTIONAL; omit it to match the value across any detail name.
+     *   - Multiple filters are AND-ed against the SAME transaction (the rotating gateway is just another pair).
+     *   - At most 10 filters are allowed.
+     *
+     * The example values below are illustrative - substitute the transaction id / auth code / amount / dates
+     * from your own gateway or chargeback record.
+     */
+    public static void execute() throws ApiException {
+        OrderApi orderApi = new OrderApi(Constants.API_KEY);
+        String expansion = "summary,payment,payment.transaction";
+
+        // Search #1 - reverse-lookup an order from a gateway transaction id.
+        // The two filters are AND-ed against the SAME transaction: the rotating gateway code AND the gateway transaction id.
+        OrderQueryPaymentTransactionFilter gatewayFilter = new OrderQueryPaymentTransactionFilter();
+        gatewayFilter.setName("rotatingTransactionGatewayCode");
+        gatewayFilter.setValue("NMI");
+        OrderQueryPaymentTransactionFilter transactionIdFilter = new OrderQueryPaymentTransactionFilter();
+        transactionIdFilter.setName("transactionid");
+        transactionIdFilter.setValue("12244247793");
+        // Tip: to match a value under ANY detail name, leave name unset.
+
+        OrderQuery query1 = new OrderQuery();
+        query1.setQueryTarget(OrderQuery.QueryTargetEnum.CACHE); // transaction-detail search requires the cache
+        query1.setPaymentTransactionFilters(Arrays.asList(gatewayFilter, transactionIdFilter));
+
+        OrdersResponse response1 = orderApi.getOrdersByQuery(query1, 200, 0, null, expansion);
+        printMatches("Search by transaction id", response1);
+
+        // Search #2 - reconcile a chargeback when you do not have the order id.
+        // The auth code from the chargeback file is stored as the "authcode" detail; combine it with the
+        // transaction amount (total) and a payment date window to uniquely identify the order.
+        OrderQueryPaymentTransactionFilter authcodeFilter = new OrderQueryPaymentTransactionFilter();
+        authcodeFilter.setName("authcode");
+        authcodeFilter.setValue("100304");
+
+        OrderQuery query2 = new OrderQuery();
+        query2.setQueryTarget(OrderQuery.QueryTargetEnum.CACHE);
+        query2.setPaymentTransactionFilters(Arrays.asList(authcodeFilter));
+        query2.setTotal(new BigDecimal("77.00"));
+        query2.setPaymentDateBegin("2026-06-29T00:00:00+00:00");
+        query2.setPaymentDateEnd("2026-07-01T00:00:00+00:00");
+
+        OrdersResponse response2 = orderApi.getOrdersByQuery(query2, 200, 0, null, expansion);
+        printMatches("Chargeback reconciliation", response2);
+    }
+
+    private static void printMatches(String label, OrdersResponse response) {
+        List<Order> orders = response.getOrders() != null ? response.getOrders() : new ArrayList<>();
+        System.out.println(label + ": " + orders.size() + " order(s) matched");
+        for (Order order : orders) {
+            System.out.println("  " + order.getOrderId());
+        }
+    }
+}

--- a/javascript/order/searchOrdersByPaymentTransaction.js
+++ b/javascript/order/searchOrdersByPaymentTransaction.js
@@ -1,0 +1,65 @@
+import {orderApi} from '../api.js';
+
+/**
+ * Search orders by the key/value pairs recorded on a payment transaction.
+ *
+ * Each payment transaction stores the gateway's response as a set of name/value detail pairs
+ * (payment.transactions[].details[], e.g. authcode, transactionid, rotatingTransactionGatewayCode).
+ * The payment_transaction_filters field on the order query matches against those pairs, letting you
+ * reverse-lookup an order from a gateway/processor transaction id, or reconcile a chargeback.
+ *
+ * Rules enforced by the API:
+ *   - query_target MUST be "cache" (ElasticSearch); the database path cannot search transaction details.
+ *   - Each filter value is REQUIRED and matched EXACTLY (no wildcards).
+ *   - A filter name is OPTIONAL; omit it to match the value across any detail name.
+ *   - Multiple filters are AND-ed against the SAME transaction (the rotating gateway is just another pair).
+ *   - At most 10 filters are allowed.
+ *
+ * The example values below are illustrative - substitute the transaction id / auth code / amount / dates
+ * from your own gateway or chargeback record.
+ */
+
+function printMatches(label, response) {
+    const orders = response.orders ?? [];
+    console.log(`${label}: ${orders.length} order(s) matched`);
+    orders.forEach(order => console.log(`  ${order.order_id}`));
+}
+
+// The JavaScript SDK uses callbacks; wrap getOrdersByQuery in a promise for async/await.
+function getOrdersByQuery(query, options) {
+    return new Promise((resolve, reject) => {
+        orderApi.getOrdersByQuery(query, options, (error, data) => error ? reject(error) : resolve(data));
+    });
+}
+
+async function execute() {
+    const expansion = 'summary,payment,payment.transaction';
+
+    // Search #1 - reverse-lookup an order from a gateway transaction id.
+    // The two filters are AND-ed against the SAME transaction: the rotating gateway code AND the gateway transaction id.
+    const query1 = {
+        query_target: 'cache', // transaction-detail search requires the cache
+        payment_transaction_filters: [
+            {name: 'rotatingTransactionGatewayCode', value: 'NMI'},
+            {name: 'transactionid', value: '12244247793'}
+        ]
+        // Tip: to match a value under ANY detail name, omit name: {value: '12244247793'}
+    };
+    const response1 = await getOrdersByQuery(query1, {_limit: 200, _offset: 0, _expand: expansion});
+    printMatches('Search by transaction id', response1);
+
+    // Search #2 - reconcile a chargeback when you do not have the order id.
+    // The auth code from the chargeback file is stored as the "authcode" detail; combine it with the
+    // transaction amount (total) and a payment date window to uniquely identify the order.
+    const query2 = {
+        query_target: 'cache',
+        payment_transaction_filters: [{name: 'authcode', value: '100304'}],
+        total: 77.00,
+        payment_date_begin: '2026-06-29T00:00:00+00:00',
+        payment_date_end: '2026-07-01T00:00:00+00:00'
+    };
+    const response2 = await getOrdersByQuery(query2, {_limit: 200, _offset: 0, _expand: expansion});
+    printMatches('Chargeback reconciliation', response2);
+}
+
+execute().catch(console.error);

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "luxon": "3.2.1",
         "ssl-root-cas": "^1.2.3",
-        "ultra_cart_rest_api_v2": "4.1.109"
+        "ultra_cart_rest_api_v2": "4.1.119"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1252,9 +1252,9 @@
       }
     },
     "node_modules/ultra_cart_rest_api_v2": {
-      "version": "4.1.109",
-      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.109.tgz",
-      "integrity": "sha512-Rosqri2yLkuuguojz+PMS6COp+Vm2A0VkX9kwmw9BhD4k/toO/OQ1X3hfwmacT5WKUOeIPlSUlytoSFU/77VCw==",
+      "version": "4.1.119",
+      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.119.tgz",
+      "integrity": "sha512-sC8pzgHhFZYwbmUziHsZB6bdoCtXnC+enwVf3PjvEtWDXVC/GVSMQTJEWBqwTeLKFYGaO+8LZknXYihVBrTOpA==",
       "license": "Unlicense",
       "dependencies": {
         "@babel/cli": "^7.0.0",
@@ -2202,9 +2202,9 @@
       }
     },
     "ultra_cart_rest_api_v2": {
-      "version": "4.1.109",
-      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.109.tgz",
-      "integrity": "sha512-Rosqri2yLkuuguojz+PMS6COp+Vm2A0VkX9kwmw9BhD4k/toO/OQ1X3hfwmacT5WKUOeIPlSUlytoSFU/77VCw==",
+      "version": "4.1.119",
+      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.119.tgz",
+      "integrity": "sha512-sC8pzgHhFZYwbmUziHsZB6bdoCtXnC+enwVf3PjvEtWDXVC/GVSMQTJEWBqwTeLKFYGaO+8LZknXYihVBrTOpA==",
       "requires": {
         "@babel/cli": "^7.0.0",
         "superagent": "^5.3.0"

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "luxon": "3.2.1",
     "ssl-root-cas": "^1.2.3",
-    "ultra_cart_rest_api_v2": "4.1.109"
+    "ultra_cart_rest_api_v2": "4.1.119"
   }
 }

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "ultracart/rest_api_v2_sdk_php": "4.1.109"
+        "ultracart/rest_api_v2_sdk_php": "4.1.119"
     },
     "config": {
         "discard-changes": true

--- a/php/order/searchOrdersByPaymentTransaction.php
+++ b/php/order/searchOrdersByPaymentTransaction.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * Search orders by the key/value pairs recorded on a payment transaction.
+ *
+ * Each payment transaction stores the gateway's response as a set of name/value detail pairs
+ * (payment.transactions[].details[], e.g. authcode, transactionid, rotatingTransactionGatewayCode).
+ * The payment_transaction_filters field on the order query matches against those pairs, letting you
+ * reverse-lookup an order from a gateway/processor transaction id, or reconcile a chargeback.
+ *
+ * Rules enforced by the API:
+ *   - query_target MUST be "cache" (ElasticSearch); the database path cannot search transaction details.
+ *   - Each filter value is REQUIRED and matched EXACTLY (no wildcards).
+ *   - A filter name is OPTIONAL; omit it to match the value across any detail name.
+ *   - Multiple filters are AND-ed against the SAME transaction (the rotating gateway is just another pair).
+ *   - At most 10 filters are allowed.
+ *
+ * The example values below are illustrative - substitute the transaction id / auth code / amount / dates
+ * from your own gateway or chargeback record.
+ */
+
+use ultracart\v2\api\OrderApi;
+use ultracart\v2\models\OrderQuery;
+use ultracart\v2\models\OrderQueryPaymentTransactionFilter;
+
+require_once '../vendor/autoload.php';
+require_once '../constants.php';
+
+$order_api = OrderApi::usingApiKey(Constants::API_KEY);
+$expansion = 'summary,payment,payment.transaction';
+
+function print_matches(string $label, $api_response): void
+{
+    $orders = $api_response->getOrders() ?? [];
+    echo $label . ': ' . count($orders) . " order(s) matched\n";
+    foreach ($orders as $order) {
+        echo '  ' . $order->getOrderId() . "\n";
+    }
+}
+
+// Search #1 - reverse-lookup an order from a gateway transaction id.
+// The two filters are AND-ed against the SAME transaction: the rotating gateway code AND the gateway transaction id.
+$query = new OrderQuery();
+$query->setQueryTarget('cache'); // transaction-detail search requires the cache
+$query->setPaymentTransactionFilters([
+    new OrderQueryPaymentTransactionFilter(['name' => 'rotatingTransactionGatewayCode', 'value' => 'NMI']),
+    new OrderQueryPaymentTransactionFilter(['name' => 'transactionid', 'value' => '12244247793']),
+]);
+// Tip: to match a value under ANY detail name, omit name:
+//   new OrderQueryPaymentTransactionFilter(['value' => '12244247793'])
+$response = $order_api->getOrdersByQuery($query, 200, 0, null, $expansion);
+print_matches('Search by transaction id', $response);
+
+// Search #2 - reconcile a chargeback when you do not have the order id.
+// The auth code from the chargeback file is stored as the "authcode" detail; combine it with the
+// transaction amount (total) and a payment date window to uniquely identify the order.
+$query = new OrderQuery();
+$query->setQueryTarget('cache');
+$query->setPaymentTransactionFilters([
+    new OrderQueryPaymentTransactionFilter(['name' => 'authcode', 'value' => '100304']),
+]);
+$query->setTotal(77.00);
+$query->setPaymentDateBegin('2026-06-29T00:00:00+00:00');
+$query->setPaymentDateEnd('2026-07-01T00:00:00+00:00');
+$response = $order_api->getOrdersByQuery($query, 200, 0, null, $expansion);
+print_matches('Chargeback reconciliation', $response);

--- a/python/order/search_orders_by_payment_transaction.py
+++ b/python/order/search_orders_by_payment_transaction.py
@@ -1,0 +1,69 @@
+# Search orders by the key/value pairs recorded on a payment transaction.
+#
+# Each payment transaction stores the gateway's response as a set of name/value detail pairs
+# (payment.transactions[].details[], e.g. authcode, transactionid, rotatingTransactionGatewayCode).
+# The payment_transaction_filters field on the order query matches against those pairs, letting you
+# reverse-lookup an order from a gateway/processor transaction id, or reconcile a chargeback.
+#
+# Rules enforced by the API:
+#   - query_target MUST be "cache" (ElasticSearch); the database path cannot search transaction details.
+#   - Each filter value is REQUIRED and matched EXACTLY (no wildcards).
+#   - A filter name is OPTIONAL; omit it to match the value across any detail name.
+#   - Multiple filters are AND-ed against the SAME transaction (the rotating gateway is just another pair).
+#   - At most 10 filters are allowed.
+#
+# The example values below are illustrative - substitute the transaction id / auth code / amount / dates
+# from your own gateway or chargeback record.
+
+from ultracart.apis import OrderApi
+from ultracart.model.order_query import OrderQuery
+from ultracart.model.order_query_payment_transaction_filter import OrderQueryPaymentTransactionFilter
+from ultracart.rest import ApiException
+from samples import api_client
+
+api_instance = OrderApi(api_client())
+expansion = 'summary,payment,payment.transaction'
+
+
+def print_matches(label, api_response):
+    orders = api_response.orders or []
+    print(f"{label}: {len(orders)} order(s) matched")
+    for order in orders:
+        print(f"  {order.order_id}")
+
+
+# Search #1 - reverse-lookup an order from a gateway transaction id.
+# The two filters are AND-ed against the SAME transaction: the rotating gateway code AND the gateway transaction id.
+try:
+    query = OrderQuery(
+        query_target='cache',  # transaction-detail search requires the cache
+        payment_transaction_filters=[
+            OrderQueryPaymentTransactionFilter(name='rotatingTransactionGatewayCode', value='NMI'),
+            OrderQueryPaymentTransactionFilter(name='transactionid', value='12244247793'),
+        ],
+    )
+    # Tip: to match a value under ANY detail name, omit name:
+    #   OrderQueryPaymentTransactionFilter(value='12244247793')
+    response = api_instance.get_orders_by_query(order_query=query, limit=200, offset=0, expand=expansion)
+    print_matches('Search by transaction id', response)
+except ApiException as e:
+    print("Exception when calling OrderApi->get_orders_by_query: %s\n" % e)
+
+
+# Search #2 - reconcile a chargeback when you do not have the order id.
+# The auth code from the chargeback file is stored as the "authcode" detail; combine it with the
+# transaction amount (total) and a payment date window to uniquely identify the order.
+try:
+    query = OrderQuery(
+        query_target='cache',
+        payment_transaction_filters=[
+            OrderQueryPaymentTransactionFilter(name='authcode', value='100304'),
+        ],
+        total=77.00,
+        payment_date_begin='2026-06-29T00:00:00+00:00',
+        payment_date_end='2026-07-01T00:00:00+00:00',
+    )
+    response = api_instance.get_orders_by_query(order_query=query, limit=200, offset=0, expand=expansion)
+    print_matches('Chargeback reconciliation', response)
+except ApiException as e:
+    print("Exception when calling OrderApi->get_orders_by_query: %s\n" % e)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,1 +1,1 @@
-ultracart-rest-sdk==4.1.109
+ultracart-rest-sdk==4.1.119

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'rubocop', group: 'development'
-gem 'ultracart_api', '4.1.109'
+gem 'ultracart_api', '4.1.119'

--- a/ruby/order/search_orders_by_payment_transaction.rb
+++ b/ruby/order/search_orders_by_payment_transaction.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'ultracart_api'
+require_relative '../constants'
+
+=begin
+ Search orders by the key/value pairs recorded on a payment transaction.
+
+ Each payment transaction stores the gateway's response as a set of name/value detail pairs
+ (payment.transactions[].details[], e.g. authcode, transactionid, rotatingTransactionGatewayCode).
+ The payment_transaction_filters field on the order query matches against those pairs, letting you
+ reverse-lookup an order from a gateway/processor transaction id, or reconcile a chargeback.
+
+ Rules enforced by the API:
+   - query_target MUST be "cache" (ElasticSearch); the database path cannot search transaction details.
+   - Each filter value is REQUIRED and matched EXACTLY (no wildcards).
+   - A filter name is OPTIONAL; omit it to match the value across any detail name.
+   - Multiple filters are AND-ed against the SAME transaction (the rotating gateway is just another pair).
+   - At most 10 filters are allowed.
+
+ The example values below are illustrative - substitute the transaction id / auth code / amount / dates
+ from your own gateway or chargeback record.
+=end
+
+order_api = UltracartClient::OrderApi.new_using_api_key(Constants::API_KEY)
+expansion = 'summary,payment,payment.transaction'
+
+def print_matches(label, api_response)
+  orders = api_response.orders || []
+  puts "#{label}: #{orders.length} order(s) matched"
+  orders.each { |order| puts "  #{order.order_id}" }
+end
+
+# Search #1 - reverse-lookup an order from a gateway transaction id.
+# The two filters are AND-ed against the SAME transaction: the rotating gateway code AND the gateway transaction id.
+query = UltracartClient::OrderQuery.new(
+  query_target: 'cache', # transaction-detail search requires the cache
+  payment_transaction_filters: [
+    UltracartClient::OrderQueryPaymentTransactionFilter.new(name: 'rotatingTransactionGatewayCode', value: 'NMI'),
+    UltracartClient::OrderQueryPaymentTransactionFilter.new(name: 'transactionid', value: '12244247793')
+  ]
+)
+# Tip: to match a value under ANY detail name, omit name:
+#   UltracartClient::OrderQueryPaymentTransactionFilter.new(value: '12244247793')
+response = order_api.get_orders_by_query(
+  order_query: query,
+  opts: { '_limit' => 200, '_offset' => 0, '_expand' => expansion }
+)
+print_matches('Search by transaction id', response)
+
+# Search #2 - reconcile a chargeback when you do not have the order id.
+# The auth code from the chargeback file is stored as the "authcode" detail; combine it with the
+# transaction amount (total) and a payment date window to uniquely identify the order.
+query = UltracartClient::OrderQuery.new(
+  query_target: 'cache',
+  payment_transaction_filters: [
+    UltracartClient::OrderQueryPaymentTransactionFilter.new(name: 'authcode', value: '100304')
+  ],
+  total: 77.00,
+  payment_date_begin: '2026-06-29T00:00:00+00:00',
+  payment_date_end: '2026-07-01T00:00:00+00:00'
+)
+response = order_api.get_orders_by_query(
+  order_query: query,
+  opts: { '_limit' => 200, '_offset' => 0, '_expand' => expansion }
+)
+print_matches('Chargeback reconciliation', response)

--- a/typescript/order/SearchOrdersByPaymentTransaction.ts
+++ b/typescript/order/SearchOrdersByPaymentTransaction.ts
@@ -1,0 +1,73 @@
+import {orderApi} from '../api';
+import {
+    OrderQuery,
+    OrdersResponse,
+    Order
+} from 'ultracart_rest_api_v2_typescript';
+
+/**
+ * Search orders by the key/value pairs recorded on a payment transaction.
+ *
+ * Each payment transaction stores the gateway's response as a set of name/value detail pairs
+ * (payment.transactions[].details[], e.g. authcode, transactionid, rotatingTransactionGatewayCode).
+ * The payment_transaction_filters field on the order query matches against those pairs, letting you
+ * reverse-lookup an order from a gateway/processor transaction id, or reconcile a chargeback.
+ *
+ * Rules enforced by the API:
+ *   - query_target MUST be "cache" (ElasticSearch); the database path cannot search transaction details.
+ *   - Each filter value is REQUIRED and matched EXACTLY (no wildcards).
+ *   - A filter name is OPTIONAL; omit it to match the value across any detail name.
+ *   - Multiple filters are AND-ed against the SAME transaction (the rotating gateway is just another pair).
+ *   - At most 10 filters are allowed.
+ *
+ * The example values below are illustrative - substitute the transaction id / auth code / amount / dates
+ * from your own gateway or chargeback record.
+ */
+
+function printMatches(label: string, response: OrdersResponse): void {
+    const orders: Order[] = response.orders ?? [];
+    console.log(`${label}: ${orders.length} order(s) matched`);
+    orders.forEach(order => console.log(`  ${order.order_id}`));
+}
+
+async function execute(): Promise<void> {
+    const expansion = 'summary,payment,payment.transaction';
+
+    // Search #1 - reverse-lookup an order from a gateway transaction id.
+    // The two filters are AND-ed against the SAME transaction: the rotating gateway code AND the gateway transaction id.
+    const query1: OrderQuery = {
+        query_target: 'cache', // transaction-detail search requires the cache
+        payment_transaction_filters: [
+            {name: 'rotatingTransactionGatewayCode', value: 'NMI'},
+            {name: 'transactionid', value: '12244247793'}
+        ]
+        // Tip: to match a value under ANY detail name, omit name: {value: '12244247793'}
+    };
+    const response1: OrdersResponse = await orderApi.getOrdersByQuery({
+        orderQuery: query1,
+        limit: 200,
+        offset: 0,
+        expand: expansion
+    });
+    printMatches('Search by transaction id', response1);
+
+    // Search #2 - reconcile a chargeback when you do not have the order id.
+    // The auth code from the chargeback file is stored as the "authcode" detail; combine it with the
+    // transaction amount (total) and a payment date window to uniquely identify the order.
+    const query2: OrderQuery = {
+        query_target: 'cache',
+        payment_transaction_filters: [{name: 'authcode', value: '100304'}],
+        total: 77.00,
+        payment_date_begin: '2026-06-29T00:00:00+00:00',
+        payment_date_end: '2026-07-01T00:00:00+00:00'
+    };
+    const response2: OrdersResponse = await orderApi.getOrdersByQuery({
+        orderQuery: query2,
+        limit: 200,
+        offset: 0,
+        expand: expansion
+    });
+    printMatches('Chargeback reconciliation', response2);
+}
+
+execute().catch(console.error);

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -7,7 +7,7 @@
     "@types/node": "^16.18.126",
     "luxon": "2.5.2",
     "typescript": "^4.9.5",
-    "ultracart_rest_api_v2_typescript": "4.1.109",
+    "ultracart_rest_api_v2_typescript": "4.1.119",
     "uuid": "^11.1.0"
   },
   "author": "UltraCart",


### PR DESCRIPTION
## Summary
Adds `SearchOrdersByPaymentTransaction` samples across all 8 languages demonstrating the new `payment_transaction_filters` field on `OrderQuery` / `getOrdersByQuery`, which searches orders by the key/value pairs recorded on a payment transaction (`payment.transactions[].details[]`).

Each sample shows two searches:
1. **Reverse-lookup by a gateway transaction id** — multi-pair AND (`rotatingTransactionGatewayCode=NMI` + `transactionid=...`), with a value-only variant in comments.
2. **Chargeback reconciliation** — `authcode` + transaction amount (`total`) + a `payment_date` window.

The samples document the API rules: `query_target=cache` is required, each filter `value` is required and `name` is optional (omit to match across any detail name), values are matched exactly (no wildcards), multiple filters are AND-ed against the same transaction, and at most 10 filters are allowed.

## SDK version
Bumps the SDK dependency from **4.1.109 → 4.1.119** (the version that introduces `payment_transaction_filters`) in every language manifest.

## Files
- New: `<lang>/order/SearchOrdersByPaymentTransaction.*` (Java under `java/src/order/`) and `curl/order/searchOrdersByPaymentTransaction.curl`
- Modified: language dependency manifests + `csharp/SDKSample.csproj` (added the Compile entry)

## Verification
- Java: `mvn compile` against `rest-sdk-4.1.119.jar` ✅
- TypeScript: `tsc --noEmit` against 4.1.119 types ✅ (0 errors)
- C#: API surface confirmed via DLL reflection (`QueryTargetEnum.Cache`, `PaymentTransactionFilters` list, `Total` decimal, filter constructor `(name, value)`)
- PHP / Ruby / JS: syntax lint ✅
- Python: runs end-to-end (builds and serializes the request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
