### PR TITLE
Add order card BIN + last four search samples across 8 languages (SDK 4.1.125)

### DIFF
--- a/csharp/SDKSample.csproj
+++ b/csharp/SDKSample.csproj
@@ -362,6 +362,7 @@
     <Compile Include="order\Replacement.cs" />
     <Compile Include="order\ResendReceipt.cs" />
     <Compile Include="order\ResendShipmentConfirmation.cs" />
+    <Compile Include="order\SearchOrdersByCardBinLastFour.cs" />
     <Compile Include="order\SearchOrdersByPaymentTransaction.cs" />
     <Compile Include="order\UnblockRefundOnOrder.cs" />
     <Compile Include="order\UpdateAccountsReceivableRetryConfig.cs" />
@@ -624,8 +625,8 @@
     <Compile Include="workflow\UpdateWorkflowTask.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="com.ultracart.admin.v2, Version=4.1.119.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\com.ultracart.admin.v2.4.1.119\lib\net48\com.ultracart.admin.v2.dll</HintPath>
+    <Reference Include="com.ultracart.admin.v2, Version=4.1.125.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\com.ultracart.admin.v2.4.1.125\lib\net48\com.ultracart.admin.v2.dll</HintPath>
     </Reference>
     <Reference Include="JsonSubTypes, Version=1.7.0.0, Culture=neutral, PublicKeyToken=ee75fc290dbc1176">
       <HintPath>packages\JsonSubTypes.1.7.0\lib\net40\JsonSubTypes.dll</HintPath>

--- a/csharp/order/SearchOrdersByCardBinLastFour.cs
+++ b/csharp/order/SearchOrdersByCardBinLastFour.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using com.ultracart.admin.v2.Api;
+using com.ultracart.admin.v2.Model;
+
+namespace SdkSample.order
+{
+    public class SearchOrdersByCardBinLastFour
+    {
+        /*
+         * Search orders by the card BIN (first six digits) plus the last four digits.
+         *
+         * A dispute or chargeback record from your gateway rarely carries the UltraCart order id, but it almost
+         * always carries the card BIN, the last four digits, the transaction amount and the transaction date.
+         * Matching on date + total + last four alone tends to return many orders, especially for subscription
+         * merchants where rebills share the same amount. Adding the BIN pins the search to the specific card.
+         *
+         * Rules enforced by the API:
+         *   - card_bin and card_last4 MUST be supplied together; neither works on its own.
+         *   - card_bin is exactly 6 digits, card_last4 is exactly 4 digits (digits only).
+         *   - ALWAYS send four digits in card_last4, including for American Express.
+         *   - payment_date_begin AND payment_date_end are REQUIRED alongside the card fields.
+         *   - The search is served from the cache; leave query_target unset (an explicit "origin" is rejected).
+         *
+         * A malformed card filter is a hard 400 rather than a silently ignored parameter, so you can never
+         * mistake an unfiltered result set for a set of genuine card matches.
+         *
+         * The example values below are illustrative - substitute the BIN / last four / amount / dates from your
+         * own gateway or chargeback record.
+         */
+        public static void Execute()
+        {
+            OrderApi orderApi = new OrderApi(Constants.ApiKey);
+            string expansion = "summary,payment,billing";
+
+            // Search #1 - reconcile a dispute using the card and a payment date window.
+            // Widen the window about a week on either side of the transaction date. That is inexpensive here because
+            // the card is doing the real narrowing, and it absorbs any timezone difference between your gateway's
+            // reporting and the payment timestamp recorded on the order.
+            OrderQuery query1 = new OrderQuery
+            {
+                CardBin = "427162",
+                CardLast4 = "6258",
+                PaymentDateBegin = "2026-07-14T00:00:00+00:00",
+                PaymentDateEnd = "2026-07-28T23:59:59+00:00"
+            };
+            OrdersResponse response1 = orderApi.GetOrdersByQuery(query1, 200, 0, null, expansion);
+            PrintMatches("Dispute reconciliation by card", response1);
+
+            // Search #2 - add the transaction amount when you trust it.
+            // Include total for extra precision. Leave it off when partial captures, surcharges or currency
+            // conversion make an exact amount match unreliable.
+            OrderQuery query2 = new OrderQuery
+            {
+                CardBin = "427162",
+                CardLast4 = "6258",
+                PaymentDateBegin = "2026-07-14T00:00:00+00:00",
+                PaymentDateEnd = "2026-07-28T23:59:59+00:00",
+                Total = 49.95m
+            };
+            OrdersResponse response2 = orderApi.GetOrdersByQuery(query2, 200, 0, null, expansion);
+            PrintMatches("Dispute reconciliation by card and amount", response2);
+
+            // Search #3 - American Express. Still send FOUR digits in card_last4.
+            // The API applies the AMEX specific reduction internally; do not send three digits.
+            OrderQuery query3 = new OrderQuery
+            {
+                CardBin = "371234",
+                CardLast4 = "5678",
+                PaymentDateBegin = "2026-07-14T00:00:00+00:00",
+                PaymentDateEnd = "2026-07-28T23:59:59+00:00"
+            };
+            OrdersResponse response3 = orderApi.GetOrdersByQuery(query3, 200, 0, null, expansion);
+            PrintMatches("American Express", response3);
+        }
+
+        private static void PrintMatches(string label, OrdersResponse response)
+        {
+            List<Order> orders = response.Orders ?? new List<Order>();
+            Console.WriteLine($"{label}: {orders.Count} order(s) matched");
+            foreach (Order order in orders)
+            {
+                Console.WriteLine($"  {order.OrderId}");
+            }
+        }
+    }
+}

--- a/csharp/packages.config
+++ b/csharp/packages.config
@@ -16,5 +16,5 @@
   <package id="System.Text.Json" version="9.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
-  <package id="com.ultracart.admin.v2" version="4.1.119" targetFramework="net48" />
+  <package id="com.ultracart.admin.v2" version="4.1.125" targetFramework="net48" />
 </packages>

--- a/curl/order/searchOrdersByCardBinLastFour.curl
+++ b/curl/order/searchOrdersByCardBinLastFour.curl
@@ -1,0 +1,108 @@
+**Search orders by the card BIN (first six digits) plus the last four digits.**
+
+A dispute or chargeback record from your gateway rarely carries the UltraCart order id, but it almost always
+carries the card BIN, the last four digits, the transaction amount and the transaction date. Matching on date +
+total + last four alone tends to return many orders, especially for subscription merchants where rebills share the
+same amount. Adding the BIN pins the search to the specific card. Rules: `card_bin` and `card_last4` must be
+supplied together (6 digits and 4 digits, digits only); always send four digits in `card_last4` including for
+American Express; `payment_date_begin` and `payment_date_end` are required alongside the card fields; leave
+`query_target` unset, as the search is served from the cache and an explicit `origin` is rejected. A malformed
+card filter is a hard 400 rather than a silently ignored parameter. The example values below are illustrative.
+
+**Request \[[Create API Key](https://ultracart.atlassian.net/wiki/spaces/ucdoc/pages/38688545/API+Simple+Key)\]**
+```bash
+curl -X POST "https://secure.ultracart.com/rest/v2/order/orders/query\\ \
+?_limit=10&_offset=0&_expand=summary%2Cpayment%2Cbilling" \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
+  -H "X-UltraCart-Api-Version: 2017-03-01" \
+  -H "x-ultracart-simple-key: <YOUR_ULTRACART_SIMPLE_KEY>" \
+  -d $'{
+    "card_bin": "427162",
+    "card_last4": "6258",
+    "payment_date_begin": "2026-07-14T00:00:00+00:00",
+    "payment_date_end": "2026-07-28T23:59:59+00:00",
+    "total": 49.95
+}'
+```
+
+**Response Headers**
+```html
+Status: 200 OK
+X-UltraCart-Request-Id: 00234A2DB61DBC0199BFED658A80011
+Content-Type: application/json; charset=UTF-8
+Transfer-Encoding: chunked
+```
+
+**Response Body**
+```json
+{
+    "orders": [
+        {
+            "merchant_id": "DEMO",
+            "order_id": "DEMO-0009142207",
+            "current_stage": "Completed Order",
+            "billing": {
+                "first_name": "Jane",
+                "last_name": "Smith",
+                "postal_code": "76537",
+                "country_code": "US",
+                "email": "jane.smith@example.com"
+            },
+            "payment": {
+                "payment_method": "Credit Card",
+                "payment_status": "Processed",
+                "payment_dts": "2026-07-21T14:32:07-04:00",
+                "credit_card": {
+                    "card_type": "VISA",
+                    "card_expiration_month": 2,
+                    "card_expiration_year": 2029
+                }
+            },
+            "summary": {
+                "total": {
+                    "value": 49.95,
+                    "localized": 49.95,
+                    "localized_formatted": "$49.95"
+                }
+            }
+        }
+    ],
+    "success": true,
+    "metadata": {
+        "result_set": {
+            "count": 1,
+            "offset": 0,
+            "limit": 10,
+            "more": false,
+            "next_offset": 0,
+            "total_records": 1
+        },
+        "payload_name": "orders"
+    }
+}
+```
+
+**Error Response - card_bin supplied without card_last4**
+```json
+{
+    "error": {
+        "developer_message": "card_bin and card_last4 must be specified together.",
+        "user_message": "card_bin and card_last4 must be specified together."
+    },
+    "success": false,
+    "metadata": {}
+}
+```
+
+**Error Response - card fields supplied without a payment date range**
+```json
+{
+    "error": {
+        "developer_message": "card_bin and card_last4 require both payment_date_begin and payment_date_end.",
+        "user_message": "card_bin and card_last4 require both payment_date_begin and payment_date_end."
+    },
+    "success": false,
+    "metadata": {}
+}
+```

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.ultracart</groupId>
             <artifactId>rest-sdk</artifactId>
-            <version>4.1.119</version>
+            <version>4.1.125</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/java/src/order/SearchOrdersByCardBinLastFour.java
+++ b/java/src/order/SearchOrdersByCardBinLastFour.java
@@ -1,0 +1,85 @@
+package order;
+
+import com.ultracart.admin.v2.OrderApi;
+import com.ultracart.admin.v2.models.Order;
+import com.ultracart.admin.v2.models.OrderQuery;
+import com.ultracart.admin.v2.models.OrdersResponse;
+import com.ultracart.admin.v2.util.ApiException;
+import common.Constants;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SearchOrdersByCardBinLastFour {
+    /*
+     * Search orders by the card BIN (first six digits) plus the last four digits.
+     *
+     * A dispute or chargeback record from your gateway rarely carries the UltraCart order id, but it almost
+     * always carries the card BIN, the last four digits, the transaction amount and the transaction date.
+     * Matching on date + total + last four alone tends to return many orders, especially for subscription
+     * merchants where rebills share the same amount. Adding the BIN pins the search to the specific card.
+     *
+     * Rules enforced by the API:
+     *   - card_bin and card_last4 MUST be supplied together; neither works on its own.
+     *   - card_bin is exactly 6 digits, card_last4 is exactly 4 digits (digits only).
+     *   - ALWAYS send four digits in card_last4, including for American Express.
+     *   - payment_date_begin AND payment_date_end are REQUIRED alongside the card fields.
+     *   - The search is served from the cache; leave query_target unset (an explicit "origin" is rejected).
+     *
+     * A malformed card filter is a hard 400 rather than a silently ignored parameter, so you can never
+     * mistake an unfiltered result set for a set of genuine card matches.
+     *
+     * The example values below are illustrative - substitute the BIN / last four / amount / dates from your
+     * own gateway or chargeback record.
+     */
+    public static void execute() throws ApiException {
+        OrderApi orderApi = new OrderApi(Constants.API_KEY);
+        String expansion = "summary,payment,billing";
+
+        // Search #1 - reconcile a dispute using the card and a payment date window.
+        // Widen the window about a week on either side of the transaction date. That is inexpensive here because
+        // the card is doing the real narrowing, and it absorbs any timezone difference between your gateway's
+        // reporting and the payment timestamp recorded on the order.
+        OrderQuery query1 = new OrderQuery();
+        query1.setCardBin("427162");
+        query1.setCardLast4("6258");
+        query1.setPaymentDateBegin("2026-07-14T00:00:00+00:00");
+        query1.setPaymentDateEnd("2026-07-28T23:59:59+00:00");
+
+        OrdersResponse response1 = orderApi.getOrdersByQuery(query1, 200, 0, null, expansion);
+        printMatches("Dispute reconciliation by card", response1);
+
+        // Search #2 - add the transaction amount when you trust it.
+        // Include total for extra precision. Leave it off when partial captures, surcharges or currency
+        // conversion make an exact amount match unreliable.
+        OrderQuery query2 = new OrderQuery();
+        query2.setCardBin("427162");
+        query2.setCardLast4("6258");
+        query2.setPaymentDateBegin("2026-07-14T00:00:00+00:00");
+        query2.setPaymentDateEnd("2026-07-28T23:59:59+00:00");
+        query2.setTotal(new BigDecimal("49.95"));
+
+        OrdersResponse response2 = orderApi.getOrdersByQuery(query2, 200, 0, null, expansion);
+        printMatches("Dispute reconciliation by card and amount", response2);
+
+        // Search #3 - American Express. Still send FOUR digits in card_last4.
+        // The API applies the AMEX specific reduction internally; do not send three digits.
+        OrderQuery query3 = new OrderQuery();
+        query3.setCardBin("371234");
+        query3.setCardLast4("5678");
+        query3.setPaymentDateBegin("2026-07-14T00:00:00+00:00");
+        query3.setPaymentDateEnd("2026-07-28T23:59:59+00:00");
+
+        OrdersResponse response3 = orderApi.getOrdersByQuery(query3, 200, 0, null, expansion);
+        printMatches("American Express", response3);
+    }
+
+    private static void printMatches(String label, OrdersResponse response) {
+        List<Order> orders = response.getOrders() != null ? response.getOrders() : new ArrayList<>();
+        System.out.println(label + ": " + orders.size() + " order(s) matched");
+        for (Order order : orders) {
+            System.out.println("  " + order.getOrderId());
+        }
+    }
+}

--- a/javascript/order/searchOrdersByCardBinLastFour.js
+++ b/javascript/order/searchOrdersByCardBinLastFour.js
@@ -1,0 +1,79 @@
+import {orderApi} from '../api.js';
+
+/**
+ * Search orders by the card BIN (first six digits) plus the last four digits.
+ *
+ * A dispute or chargeback record from your gateway rarely carries the UltraCart order id, but it almost
+ * always carries the card BIN, the last four digits, the transaction amount and the transaction date.
+ * Matching on date + total + last four alone tends to return many orders, especially for subscription
+ * merchants where rebills share the same amount. Adding the BIN pins the search to the specific card.
+ *
+ * Rules enforced by the API:
+ *   - card_bin and card_last4 MUST be supplied together; neither works on its own.
+ *   - card_bin is exactly 6 digits, card_last4 is exactly 4 digits (digits only).
+ *   - ALWAYS send four digits in card_last4, including for American Express.
+ *   - payment_date_begin AND payment_date_end are REQUIRED alongside the card fields.
+ *   - The search is served from the cache; leave query_target unset (an explicit "origin" is rejected).
+ *
+ * A malformed card filter is a hard 400 rather than a silently ignored parameter, so you can never
+ * mistake an unfiltered result set for a set of genuine card matches.
+ *
+ * The example values below are illustrative - substitute the BIN / last four / amount / dates from your
+ * own gateway or chargeback record.
+ */
+
+function printMatches(label, response) {
+    const orders = response.orders ?? [];
+    console.log(`${label}: ${orders.length} order(s) matched`);
+    orders.forEach(order => console.log(`  ${order.order_id}`));
+}
+
+// The JavaScript SDK uses callbacks; wrap getOrdersByQuery in a promise for async/await.
+function getOrdersByQuery(query, options) {
+    return new Promise((resolve, reject) => {
+        orderApi.getOrdersByQuery(query, options, (error, data) => error ? reject(error) : resolve(data));
+    });
+}
+
+async function execute() {
+    const expansion = 'summary,payment,billing';
+
+    // Search #1 - reconcile a dispute using the card and a payment date window.
+    // Widen the window about a week on either side of the transaction date. That is inexpensive here because
+    // the card is doing the real narrowing, and it absorbs any timezone difference between your gateway's
+    // reporting and the payment timestamp recorded on the order.
+    const query1 = {
+        card_bin: '427162',
+        card_last4: '6258',
+        payment_date_begin: '2026-07-14T00:00:00+00:00',
+        payment_date_end: '2026-07-28T23:59:59+00:00'
+    };
+    const response1 = await getOrdersByQuery(query1, {_limit: 200, _offset: 0, _expand: expansion});
+    printMatches('Dispute reconciliation by card', response1);
+
+    // Search #2 - add the transaction amount when you trust it.
+    // Include total for extra precision. Leave it off when partial captures, surcharges or currency
+    // conversion make an exact amount match unreliable.
+    const query2 = {
+        card_bin: '427162',
+        card_last4: '6258',
+        payment_date_begin: '2026-07-14T00:00:00+00:00',
+        payment_date_end: '2026-07-28T23:59:59+00:00',
+        total: 49.95
+    };
+    const response2 = await getOrdersByQuery(query2, {_limit: 200, _offset: 0, _expand: expansion});
+    printMatches('Dispute reconciliation by card and amount', response2);
+
+    // Search #3 - American Express. Still send FOUR digits in card_last4.
+    // The API applies the AMEX specific reduction internally; do not send three digits.
+    const query3 = {
+        card_bin: '371234',
+        card_last4: '5678',
+        payment_date_begin: '2026-07-14T00:00:00+00:00',
+        payment_date_end: '2026-07-28T23:59:59+00:00'
+    };
+    const response3 = await getOrdersByQuery(query3, {_limit: 200, _offset: 0, _expand: expansion});
+    printMatches('American Express', response3);
+}
+
+execute().catch(console.error);

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "luxon": "3.2.1",
         "ssl-root-cas": "^1.2.3",
-        "ultra_cart_rest_api_v2": "4.1.119"
+        "ultra_cart_rest_api_v2": "4.1.125"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1252,9 +1252,9 @@
       }
     },
     "node_modules/ultra_cart_rest_api_v2": {
-      "version": "4.1.119",
-      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.119.tgz",
-      "integrity": "sha512-sC8pzgHhFZYwbmUziHsZB6bdoCtXnC+enwVf3PjvEtWDXVC/GVSMQTJEWBqwTeLKFYGaO+8LZknXYihVBrTOpA==",
+      "version": "4.1.125",
+      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.125.tgz",
+      "integrity": "sha512-Tmw9+0k7YVzuoNHpsXmiVs+A4zBMXozlB69Dt+ANf19+EuaB9gwhCVeBYmks/Eg90aNxcuQ4jWvEUYxR6gyOMQ==",
       "license": "Unlicense",
       "dependencies": {
         "@babel/cli": "^7.0.0",
@@ -2202,9 +2202,9 @@
       }
     },
     "ultra_cart_rest_api_v2": {
-      "version": "4.1.119",
-      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.119.tgz",
-      "integrity": "sha512-sC8pzgHhFZYwbmUziHsZB6bdoCtXnC+enwVf3PjvEtWDXVC/GVSMQTJEWBqwTeLKFYGaO+8LZknXYihVBrTOpA==",
+      "version": "4.1.125",
+      "resolved": "https://registry.npmjs.org/ultra_cart_rest_api_v2/-/ultra_cart_rest_api_v2-4.1.125.tgz",
+      "integrity": "sha512-Tmw9+0k7YVzuoNHpsXmiVs+A4zBMXozlB69Dt+ANf19+EuaB9gwhCVeBYmks/Eg90aNxcuQ4jWvEUYxR6gyOMQ==",
       "requires": {
         "@babel/cli": "^7.0.0",
         "superagent": "^5.3.0"

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "luxon": "3.2.1",
     "ssl-root-cas": "^1.2.3",
-    "ultra_cart_rest_api_v2": "4.1.119"
+    "ultra_cart_rest_api_v2": "4.1.125"
   }
 }

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "ultracart/rest_api_v2_sdk_php": "4.1.119"
+        "ultracart/rest_api_v2_sdk_php": "4.1.125"
     },
     "config": {
         "discard-changes": true

--- a/php/order/searchOrdersByCardBinLastFour.php
+++ b/php/order/searchOrdersByCardBinLastFour.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * Search orders by the card BIN (first six digits) plus the last four digits.
+ *
+ * A dispute or chargeback record from your gateway rarely carries the UltraCart order id, but it almost
+ * always carries the card BIN, the last four digits, the transaction amount and the transaction date.
+ * Matching on date + total + last four alone tends to return many orders, especially for subscription
+ * merchants where rebills share the same amount. Adding the BIN pins the search to the specific card.
+ *
+ * Rules enforced by the API:
+ *   - card_bin and card_last4 MUST be supplied together; neither works on its own.
+ *   - card_bin is exactly 6 digits, card_last4 is exactly 4 digits (digits only).
+ *   - ALWAYS send four digits in card_last4, including for American Express.
+ *   - payment_date_begin AND payment_date_end are REQUIRED alongside the card fields.
+ *   - The search is served from the cache; leave query_target unset (an explicit "origin" is rejected).
+ *
+ * A malformed card filter is a hard 400 rather than a silently ignored parameter, so you can never
+ * mistake an unfiltered result set for a set of genuine card matches.
+ *
+ * The example values below are illustrative - substitute the BIN / last four / amount / dates from your
+ * own gateway or chargeback record.
+ */
+
+use ultracart\v2\api\OrderApi;
+use ultracart\v2\models\OrderQuery;
+
+require_once '../vendor/autoload.php';
+require_once '../constants.php';
+
+$order_api = OrderApi::usingApiKey(Constants::API_KEY);
+$expansion = 'summary,payment,billing';
+
+function print_matches(string $label, $api_response): void
+{
+    $orders = $api_response->getOrders() ?? [];
+    echo $label . ': ' . count($orders) . " order(s) matched\n";
+    foreach ($orders as $order) {
+        echo '  ' . $order->getOrderId() . "\n";
+    }
+}
+
+// Search #1 - reconcile a dispute using the card and a payment date window.
+// Widen the window about a week on either side of the transaction date. That is inexpensive here because
+// the card is doing the real narrowing, and it absorbs any timezone difference between your gateway's
+// reporting and the payment timestamp recorded on the order.
+$query = new OrderQuery();
+$query->setCardBin('427162');
+$query->setCardLast4('6258');
+$query->setPaymentDateBegin('2026-07-14T00:00:00+00:00');
+$query->setPaymentDateEnd('2026-07-28T23:59:59+00:00');
+$response = $order_api->getOrdersByQuery($query, 200, 0, null, $expansion);
+print_matches('Dispute reconciliation by card', $response);
+
+// Search #2 - add the transaction amount when you trust it.
+// Include total for extra precision. Leave it off when partial captures, surcharges or currency
+// conversion make an exact amount match unreliable.
+$query = new OrderQuery();
+$query->setCardBin('427162');
+$query->setCardLast4('6258');
+$query->setPaymentDateBegin('2026-07-14T00:00:00+00:00');
+$query->setPaymentDateEnd('2026-07-28T23:59:59+00:00');
+$query->setTotal(49.95);
+$response = $order_api->getOrdersByQuery($query, 200, 0, null, $expansion);
+print_matches('Dispute reconciliation by card and amount', $response);
+
+// Search #3 - American Express. Still send FOUR digits in card_last4.
+// The API applies the AMEX specific reduction internally; do not send three digits.
+$query = new OrderQuery();
+$query->setCardBin('371234');
+$query->setCardLast4('5678');
+$query->setPaymentDateBegin('2026-07-14T00:00:00+00:00');
+$query->setPaymentDateEnd('2026-07-28T23:59:59+00:00');
+$response = $order_api->getOrdersByQuery($query, 200, 0, null, $expansion);
+print_matches('American Express', $response);

--- a/python/order/search_orders_by_card_bin_last_four.py
+++ b/python/order/search_orders_by_card_bin_last_four.py
@@ -1,0 +1,83 @@
+# Search orders by the card BIN (first six digits) plus the last four digits.
+#
+# A dispute or chargeback record from your gateway rarely carries the UltraCart order id, but it almost
+# always carries the card BIN, the last four digits, the transaction amount and the transaction date.
+# Matching on date + total + last four alone tends to return many orders, especially for subscription
+# merchants where rebills share the same amount. Adding the BIN pins the search to the specific card.
+#
+# Rules enforced by the API:
+#   - card_bin and card_last4 MUST be supplied together; neither works on its own.
+#   - card_bin is exactly 6 digits, card_last4 is exactly 4 digits (digits only).
+#   - ALWAYS send four digits in card_last4, including for American Express.
+#   - payment_date_begin AND payment_date_end are REQUIRED alongside the card fields.
+#   - The search is served from the cache; leave query_target unset (an explicit "origin" is rejected).
+#
+# A malformed card filter is a hard 400 rather than a silently ignored parameter, so you can never
+# mistake an unfiltered result set for a set of genuine card matches.
+#
+# The example values below are illustrative - substitute the BIN / last four / amount / dates from your
+# own gateway or chargeback record.
+
+from ultracart.apis import OrderApi
+from ultracart.model.order_query import OrderQuery
+from ultracart.rest import ApiException
+from samples import api_client
+
+api_instance = OrderApi(api_client())
+expansion = 'summary,payment,billing'
+
+
+def print_matches(label, api_response):
+    orders = api_response.orders or []
+    print(f"{label}: {len(orders)} order(s) matched")
+    for order in orders:
+        print(f"  {order.order_id}")
+
+
+# Search #1 - reconcile a dispute using the card and a payment date window.
+# Widen the window about a week on either side of the transaction date. That is inexpensive here because
+# the card is doing the real narrowing, and it absorbs any timezone difference between your gateway's
+# reporting and the payment timestamp recorded on the order.
+try:
+    query = OrderQuery(
+        card_bin='427162',
+        card_last4='6258',
+        payment_date_begin='2026-07-14T00:00:00+00:00',
+        payment_date_end='2026-07-28T23:59:59+00:00',
+    )
+    response = api_instance.get_orders_by_query(order_query=query, limit=200, offset=0, expand=expansion)
+    print_matches('Dispute reconciliation by card', response)
+except ApiException as e:
+    print("Exception when calling OrderApi->get_orders_by_query: %s\n" % e)
+
+
+# Search #2 - add the transaction amount when you trust it.
+# Include total for extra precision. Leave it off when partial captures, surcharges or currency
+# conversion make an exact amount match unreliable.
+try:
+    query = OrderQuery(
+        card_bin='427162',
+        card_last4='6258',
+        payment_date_begin='2026-07-14T00:00:00+00:00',
+        payment_date_end='2026-07-28T23:59:59+00:00',
+        total=49.95,
+    )
+    response = api_instance.get_orders_by_query(order_query=query, limit=200, offset=0, expand=expansion)
+    print_matches('Dispute reconciliation by card and amount', response)
+except ApiException as e:
+    print("Exception when calling OrderApi->get_orders_by_query: %s\n" % e)
+
+
+# Search #3 - American Express. Still send FOUR digits in card_last4.
+# The API applies the AMEX specific reduction internally; do not send three digits.
+try:
+    query = OrderQuery(
+        card_bin='371234',
+        card_last4='5678',
+        payment_date_begin='2026-07-14T00:00:00+00:00',
+        payment_date_end='2026-07-28T23:59:59+00:00',
+    )
+    response = api_instance.get_orders_by_query(order_query=query, limit=200, offset=0, expand=expansion)
+    print_matches('American Express', response)
+except ApiException as e:
+    print("Exception when calling OrderApi->get_orders_by_query: %s\n" % e)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,1 +1,1 @@
-ultracart-rest-sdk==4.1.119
+ultracart-rest-sdk==4.1.125

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'rubocop', group: 'development'
-gem 'ultracart_api', '4.1.119'
+gem 'ultracart_api', '4.1.125'

--- a/ruby/order/search_orders_by_card_bin_last_four.rb
+++ b/ruby/order/search_orders_by_card_bin_last_four.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'ultracart_api'
+require_relative '../constants'
+
+=begin
+ Search orders by the card BIN (first six digits) plus the last four digits.
+
+ A dispute or chargeback record from your gateway rarely carries the UltraCart order id, but it almost
+ always carries the card BIN, the last four digits, the transaction amount and the transaction date.
+ Matching on date + total + last four alone tends to return many orders, especially for subscription
+ merchants where rebills share the same amount. Adding the BIN pins the search to the specific card.
+
+ Rules enforced by the API:
+   - card_bin and card_last4 MUST be supplied together; neither works on its own.
+   - card_bin is exactly 6 digits, card_last4 is exactly 4 digits (digits only).
+   - ALWAYS send four digits in card_last4, including for American Express.
+   - payment_date_begin AND payment_date_end are REQUIRED alongside the card fields.
+   - The search is served from the cache; leave query_target unset (an explicit "origin" is rejected).
+
+ A malformed card filter is a hard 400 rather than a silently ignored parameter, so you can never
+ mistake an unfiltered result set for a set of genuine card matches.
+
+ The example values below are illustrative - substitute the BIN / last four / amount / dates from your
+ own gateway or chargeback record.
+=end
+
+order_api = UltracartClient::OrderApi.new_using_api_key(Constants::API_KEY)
+expansion = 'summary,payment,billing'
+
+def print_matches(label, api_response)
+  orders = api_response.orders || []
+  puts "#{label}: #{orders.length} order(s) matched"
+  orders.each { |order| puts "  #{order.order_id}" }
+end
+
+# Search #1 - reconcile a dispute using the card and a payment date window.
+# Widen the window about a week on either side of the transaction date. That is inexpensive here because
+# the card is doing the real narrowing, and it absorbs any timezone difference between your gateway's
+# reporting and the payment timestamp recorded on the order.
+query = UltracartClient::OrderQuery.new(
+  card_bin: '427162',
+  card_last4: '6258',
+  payment_date_begin: '2026-07-14T00:00:00+00:00',
+  payment_date_end: '2026-07-28T23:59:59+00:00'
+)
+response = order_api.get_orders_by_query(
+  order_query: query,
+  opts: { '_limit' => 200, '_offset' => 0, '_expand' => expansion }
+)
+print_matches('Dispute reconciliation by card', response)
+
+# Search #2 - add the transaction amount when you trust it.
+# Include total for extra precision. Leave it off when partial captures, surcharges or currency
+# conversion make an exact amount match unreliable.
+query = UltracartClient::OrderQuery.new(
+  card_bin: '427162',
+  card_last4: '6258',
+  payment_date_begin: '2026-07-14T00:00:00+00:00',
+  payment_date_end: '2026-07-28T23:59:59+00:00',
+  total: 49.95
+)
+response = order_api.get_orders_by_query(
+  order_query: query,
+  opts: { '_limit' => 200, '_offset' => 0, '_expand' => expansion }
+)
+print_matches('Dispute reconciliation by card and amount', response)
+
+# Search #3 - American Express. Still send FOUR digits in card_last4.
+# The API applies the AMEX specific reduction internally; do not send three digits.
+query = UltracartClient::OrderQuery.new(
+  card_bin: '371234',
+  card_last4: '5678',
+  payment_date_begin: '2026-07-14T00:00:00+00:00',
+  payment_date_end: '2026-07-28T23:59:59+00:00'
+)
+response = order_api.get_orders_by_query(
+  order_query: query,
+  opts: { '_limit' => 200, '_offset' => 0, '_expand' => expansion }
+)
+print_matches('American Express', response)

--- a/typescript/order/SearchOrdersByCardBinLastFour.ts
+++ b/typescript/order/SearchOrdersByCardBinLastFour.ts
@@ -1,0 +1,92 @@
+import {orderApi} from '../api';
+import {
+    OrderQuery,
+    OrdersResponse,
+    Order
+} from 'ultracart_rest_api_v2_typescript';
+
+/**
+ * Search orders by the card BIN (first six digits) plus the last four digits.
+ *
+ * A dispute or chargeback record from your gateway rarely carries the UltraCart order id, but it almost
+ * always carries the card BIN, the last four digits, the transaction amount and the transaction date.
+ * Matching on date + total + last four alone tends to return many orders, especially for subscription
+ * merchants where rebills share the same amount. Adding the BIN pins the search to the specific card.
+ *
+ * Rules enforced by the API:
+ *   - card_bin and card_last4 MUST be supplied together; neither works on its own.
+ *   - card_bin is exactly 6 digits, card_last4 is exactly 4 digits (digits only).
+ *   - ALWAYS send four digits in card_last4, including for American Express.
+ *   - payment_date_begin AND payment_date_end are REQUIRED alongside the card fields.
+ *   - The search is served from the cache; leave query_target unset (an explicit "origin" is rejected).
+ *
+ * A malformed card filter is a hard 400 rather than a silently ignored parameter, so you can never
+ * mistake an unfiltered result set for a set of genuine card matches.
+ *
+ * The example values below are illustrative - substitute the BIN / last four / amount / dates from your
+ * own gateway or chargeback record.
+ */
+
+function printMatches(label: string, response: OrdersResponse): void {
+    const orders: Order[] = response.orders ?? [];
+    console.log(`${label}: ${orders.length} order(s) matched`);
+    orders.forEach(order => console.log(`  ${order.order_id}`));
+}
+
+async function execute(): Promise<void> {
+    const expansion = 'summary,payment,billing';
+
+    // Search #1 - reconcile a dispute using the card and a payment date window.
+    // Widen the window about a week on either side of the transaction date. That is inexpensive here because
+    // the card is doing the real narrowing, and it absorbs any timezone difference between your gateway's
+    // reporting and the payment timestamp recorded on the order.
+    const query1: OrderQuery = {
+        card_bin: '427162',
+        card_last4: '6258',
+        payment_date_begin: '2026-07-14T00:00:00+00:00',
+        payment_date_end: '2026-07-28T23:59:59+00:00'
+    };
+    const response1: OrdersResponse = await orderApi.getOrdersByQuery({
+        orderQuery: query1,
+        limit: 200,
+        offset: 0,
+        expand: expansion
+    });
+    printMatches('Dispute reconciliation by card', response1);
+
+    // Search #2 - add the transaction amount when you trust it.
+    // Include total for extra precision. Leave it off when partial captures, surcharges or currency
+    // conversion make an exact amount match unreliable.
+    const query2: OrderQuery = {
+        card_bin: '427162',
+        card_last4: '6258',
+        payment_date_begin: '2026-07-14T00:00:00+00:00',
+        payment_date_end: '2026-07-28T23:59:59+00:00',
+        total: 49.95
+    };
+    const response2: OrdersResponse = await orderApi.getOrdersByQuery({
+        orderQuery: query2,
+        limit: 200,
+        offset: 0,
+        expand: expansion
+    });
+    printMatches('Dispute reconciliation by card and amount', response2);
+
+    // Search #3 - American Express. Still send FOUR digits in card_last4.
+    // The API applies the AMEX specific reduction internally; do not send three digits.
+    const query3: OrderQuery = {
+        card_bin: '371234',
+        card_last4: '5678',
+        payment_date_begin: '2026-07-14T00:00:00+00:00',
+        payment_date_end: '2026-07-28T23:59:59+00:00'
+    };
+    const response3: OrdersResponse = await orderApi.getOrdersByQuery({
+        orderQuery: query3,
+        limit: 200,
+        offset: 0,
+        expand: expansion
+    });
+    printMatches('American Express', response3);
+}
+
+execute().catch(console.error);

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -7,7 +7,7 @@
     "@types/node": "^16.18.126",
     "luxon": "2.5.2",
     "typescript": "^4.9.5",
-    "ultracart_rest_api_v2_typescript": "4.1.119",
+    "ultracart_rest_api_v2_typescript": "4.1.125",
     "uuid": "^11.1.0"
   },
   "author": "UltraCart",


### PR DESCRIPTION
## Summary

The order query endpoint now accepts `card_bin` (first six digits) and `card_last4`, which pins a search to a specific card. This is aimed at reconciling gateway disputes and chargebacks back to the originating order.

Matching on payment date + total + last four alone tends to over-match, especially for subscription merchants whose rebills share an amount. Adding the BIN resolves the search to a single card.

## Samples added

One per language in `<lang>/order/`, following the `SearchOrdersByPaymentTransaction` pattern:

| Language | File |
|---|---|
| C# | `csharp/order/SearchOrdersByCardBinLastFour.cs` |
| curl | `curl/order/searchOrdersByCardBinLastFour.curl` |
| Java | `java/src/order/SearchOrdersByCardBinLastFour.java` |
| JavaScript | `javascript/order/searchOrdersByCardBinLastFour.js` |
| PHP | `php/order/searchOrdersByCardBinLastFour.php` |
| Python | `python/order/search_orders_by_card_bin_last_four.py` |
| Ruby | `ruby/order/search_orders_by_card_bin_last_four.rb` |
| TypeScript | `typescript/order/SearchOrdersByCardBinLastFour.ts` |

Each covers three cases:

1. Card plus a payment date window
2. The same with the transaction amount added
3. American Express, where callers still send **four** digits and the API applies the AMEX reduction internally

The curl sample additionally documents two of the 400 responses, since a malformed card filter is a hard error rather than a silently ignored parameter.

## SDK upgrade

Bumped from 4.1.119 to 4.1.125 in every sample project: `csharp/packages.config`, `csharp/SDKSample.csproj`, `java/pom.xml`, `javascript/package.json`, `javascript/package-lock.json`, `php/composer.json`, `python/requirements.txt`, `ruby/Gemfile`, `typescript/package.json`.

The npm lock file carries the real registry integrity hash for 4.1.125.

## Notes

- `SearchOrdersByCardBinLastFour.cs` is registered in `SDKSample.csproj`; the other languages need no registration.
- Example BINs and last four values are illustrative placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)