### PR TITLE
Add getOrderCustomerActivity samples and bump SDKs to 4.1.130

### DIFF
--- a/csharp/SDKSample.csproj
+++ b/csharp/SDKSample.csproj
@@ -347,6 +347,7 @@
     <Compile Include="order\GetAccountsReceivableRetryStats.cs" />
     <Compile Include="order\GetOrder.cs" />
     <Compile Include="order\GetOrderByToken.cs" />
+    <Compile Include="order\GetOrderCustomerActivity.cs" />
     <Compile Include="order\GetOrderEdiDocuments.cs" />
     <Compile Include="order\GetOrders.cs" />
     <Compile Include="order\GetOrdersBatch.cs" />
@@ -625,8 +626,8 @@
     <Compile Include="workflow\UpdateWorkflowTask.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="com.ultracart.admin.v2, Version=4.1.125.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\com.ultracart.admin.v2.4.1.125\lib\net48\com.ultracart.admin.v2.dll</HintPath>
+    <Reference Include="com.ultracart.admin.v2, Version=4.1.130.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\com.ultracart.admin.v2.4.1.130\lib\net48\com.ultracart.admin.v2.dll</HintPath>
     </Reference>
     <Reference Include="JsonSubTypes, Version=1.7.0.0, Culture=neutral, PublicKeyToken=ee75fc290dbc1176">
       <HintPath>packages\JsonSubTypes.1.7.0\lib\net40\JsonSubTypes.dll</HintPath>

--- a/csharp/order/GetOrderCustomerActivity.cs
+++ b/csharp/order/GetOrderCustomerActivity.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using com.ultracart.admin.v2.Api;
+using com.ultracart.admin.v2.Model;
+using Newtonsoft.Json;
+
+namespace SdkSample.order
+{
+    public class GetOrderCustomerActivity
+    {
+        /*
+            getOrderCustomerActivity returns the customer activity associated with the email address on an
+            order.  This includes email engagement history, email list and segment membership, lifetime
+            metrics and email suppression status.
+
+            A customer profile is NOT required and is not consulted.  The activity is keyed off the email
+            address on the order, so this works for guest orders that have never had a customer profile
+            established.  For the page views captured during the session that placed the order, use
+            GetOrderPageViewHistory instead.
+
+            If the order has no valid email address, Email and CustomerActivity both come back null.  That
+            is a successful response rather than an error - without an email there is no activity record
+            to find.
+
+            Note: Activity.Ts is a unix timestamp in milliseconds, not an ISO 8601 string like most dates
+            in this API.
+
+            Possible Errors:
+            order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+         */
+        public static void Execute()
+        {
+            OrderApi orderApi = new OrderApi(Constants.ApiKey);
+
+            string orderId = "DEMO-0009104976";
+            OrderCustomerActivityResponse response = orderApi.GetOrderCustomerActivity(orderId);
+
+            Console.WriteLine("Customer activity for: " + response.Email);
+
+            CustomerActivity customerActivity = response.CustomerActivity;
+
+            if (customerActivity == null)
+            {
+                Console.WriteLine("No customer activity found for this order.");
+                return;
+            }
+
+            Console.WriteLine("Globally unsubscribed: " + customerActivity.GlobalUnsubscribed);
+            Console.WriteLine("Spam complaint: " + customerActivity.SpamComplaint);
+
+            List<Activity> activities = customerActivity.Activities;
+
+            foreach (Activity activity in activities)
+            {
+                Console.WriteLine(JsonConvert.SerializeObject(activity,
+                    new JsonSerializerSettings { Formatting = Formatting.Indented }));
+            }
+
+        }
+    }
+}

--- a/csharp/packages.config
+++ b/csharp/packages.config
@@ -16,5 +16,5 @@
   <package id="System.Text.Json" version="9.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
-  <package id="com.ultracart.admin.v2" version="4.1.125" targetFramework="net48" />
+  <package id="com.ultracart.admin.v2" version="4.1.130" targetFramework="net48" />
 </packages>

--- a/curl/order/getOrderCustomerActivity.curl
+++ b/curl/order/getOrderCustomerActivity.curl
@@ -1,0 +1,107 @@
+**Request \[[Create API Key](https://ultracart.atlassian.net/wiki/spaces/ucdoc/pages/38688545/API+Simple+Key)\]**
+```bash
+curl -X GET "https://secure.ultracart.com/rest/v2/order/orders/DEMO-0009104976/customer_activity" \
+  -H "Accept: application/json" \
+  -H "X-UltraCart-Api-Version: 2017-03-01" \
+  -H "x-ultracart-simple-key: 976892e9c788c00199a693ade98001004b139b72bb4d470199a693ade9800100"
+```
+
+Returns the customer activity associated with the email address on the order.  A customer profile is not
+required, so this works for guest orders.  For the page views captured during the session that placed the
+order, see getOrderPageViewHistory.
+
+Note that `ts` on each activity is a unix timestamp in milliseconds, not an ISO 8601 string like most
+dates in this API.
+
+**Response Headers**
+```html
+Status: 200 OK
+X-UltraCart-Request-Id: 3F91CD07AB45E20199BFD48B4880011
+Content-Type: application/json; charset=UTF-8
+Transfer-Encoding: chunked
+Date: Tue, 07 Oct 2025 18:04:22 GMT
+```
+
+**Response Body**
+```json
+{
+    "email": "support@ultracart.com",
+    "customer_activity": {
+        "activities": [
+            {
+                "type": "email",
+                "action": "email delivery",
+                "metric": "Email Delivered",
+                "uuid": "9f4c1b7e-3d82-4a61-9c05-7e2b8d1a4f36",
+                "ts": 1759857604000,
+                "subject": "Your order has shipped",
+                "channel": "www.example.com",
+                "storefront_oid": 179661
+            },
+            {
+                "type": "email",
+                "action": "email open",
+                "metric": "Email Open",
+                "uuid": "9f4c1b7e-3d82-4a61-9c05-7e2b8d1a4f36",
+                "ts": 1759861204000,
+                "subject": "Your order has shipped",
+                "channel": "www.example.com",
+                "storefront_oid": 179661
+            }
+        ],
+        "metrics": [
+            {
+                "name": "Revenue",
+                "type": "currency",
+                "last_30": 32.85,
+                "prior_30": 0.0,
+                "all_time": 145.72,
+                "last_30_formatted": "$32.85",
+                "prior_30_formatted": "$0.00",
+                "all_time_formatted": "$145.72"
+            }
+        ],
+        "memberships": [
+            {
+                "type": "list",
+                "uuid": "cfa823c7-b7c5-4584-bc4e-e67b0edd0236",
+                "name": "Newsletter Subscribers"
+            }
+        ],
+        "global_unsubscribed": false,
+        "spam_complaint": false
+    },
+    "success": true,
+    "metadata": {}
+}
+```
+
+**Response Body \(order has no email address\)**
+```json
+{
+    "success": true,
+    "metadata": {}
+}
+```
+
+**Error Response Headers**
+```html
+Status: 400 Bad Request
+X-UltraCart-Request-Id: B7EACF19E16FA60199BFCAF7C780011
+UC-REST-ERROR: Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log.
+Content-Type: application/json; charset=UTF-8
+Connection: close
+Transfer-Encoding: chunked
+Date: Tue, 07 Oct 2025 17:52:11 GMT
+```
+
+**Error Response Body**
+```json
+{
+    "error": {
+        "developer_message": "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log.",
+        "user_message": "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+    },
+    "metadata": {}
+}
+```

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.ultracart</groupId>
             <artifactId>rest-sdk</artifactId>
-            <version>4.1.125</version>
+            <version>4.1.130</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/java/src/order/GetOrderCustomerActivity.java
+++ b/java/src/order/GetOrderCustomerActivity.java
@@ -1,0 +1,55 @@
+package order;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.ultracart.admin.v2.OrderApi;
+import com.ultracart.admin.v2.models.*;
+import com.ultracart.admin.v2.util.ApiException;
+import java.util.List;
+
+public class GetOrderCustomerActivity {
+   /*
+       getOrderCustomerActivity returns the customer activity associated with the email address on an
+       order.  This includes email engagement history, email list and segment membership, lifetime metrics
+       and email suppression status.
+
+       A customer profile is NOT required and is not consulted.  The activity is keyed off the email
+       address on the order, so this works for guest orders that have never had a customer profile
+       established.  For the page views captured during the session that placed the order, use
+       getOrderPageViewHistory instead.
+
+       If the order has no valid email address, email and customerActivity both come back null.  That is a
+       successful response rather than an error - without an email there is no activity record to find.
+
+       Note: activity.getTs() is a unix timestamp in milliseconds, not an ISO 8601 string like most dates
+       in this API.
+
+       Possible Errors:
+       order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+    */
+   public void execute() throws ApiException {
+       OrderApi orderApi = new OrderApi(common.Constants.API_KEY);
+
+       String orderId = "DEMO-0009104976";
+       OrderCustomerActivityResponse response = orderApi.getOrderCustomerActivity(orderId);
+
+       System.out.println("Customer activity for: " + response.getEmail());
+
+       CustomerActivity customerActivity = response.getCustomerActivity();
+
+       if (customerActivity == null) {
+           System.out.println("No customer activity found for this order.");
+           return;
+       }
+
+       System.out.println("Globally unsubscribed: " + customerActivity.getGlobalUnsubscribed());
+       System.out.println("Spam complaint: " + customerActivity.getSpamComplaint());
+
+       List<Activity> activities = customerActivity.getActivities();
+
+       Gson gson = new GsonBuilder().setPrettyPrinting().create();
+       for (Activity activity : activities) {
+           System.out.println(gson.toJson(activity));
+       }
+   }
+}

--- a/javascript/order/getOrderCustomerActivity.js
+++ b/javascript/order/getOrderCustomerActivity.js
@@ -1,0 +1,59 @@
+import {orderApi} from '../api.js';
+
+/**
+ * getOrderCustomerActivity returns the customer activity associated with the email address on an order.
+ * This includes email engagement history, email list and segment membership, lifetime metrics and email
+ * suppression status.
+ *
+ * A customer profile is NOT required and is not consulted.  The activity is keyed off the email address
+ * on the order, so this works for guest orders that have never had a customer profile established.  For
+ * the page views captured during the session that placed the order, use getOrderPageViewHistory instead.
+ *
+ * If the order has no valid email address, email and customer_activity both come back null.  That is a
+ * successful response rather than an error - without an email there is no activity record to find.
+ *
+ * Note: activity.ts is a unix timestamp in milliseconds, not an ISO 8601 string like most dates in this API.
+ *
+ * Possible Errors:
+ * order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+ */
+export async function execute() {
+    const orderId = "DEMO-0009104976";
+
+    try {
+        const response = await new Promise((resolve, reject) => {
+            orderApi.getOrderCustomerActivity(
+                orderId
+                , function (error, data, response) {
+                    if (error) {
+                        reject(error);
+                    } else {
+                        resolve(data);
+                    }
+                });
+        });
+
+        console.log('Customer activity for: ' + response.email);
+
+        const customerActivity = response.customer_activity;
+
+        if (!customerActivity) {
+            console.log('No customer activity found for this order.');
+            return;
+        }
+
+        console.log('Globally unsubscribed: ' + customerActivity.global_unsubscribed);
+        console.log('Spam complaint: ' + customerActivity.spam_complaint);
+
+        const activities = customerActivity.activities || [];
+
+        for (const activity of activities) {
+            console.log(new Date(activity.ts).toISOString()
+                + ' - ' + activity.type
+                + ' - ' + activity.action
+                + (activity.subject ? ' - ' + activity.subject : ''));
+        }
+    } catch (error) {
+        console.error('Error fetching customer activity:', error);
+    }
+}

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "luxon": "3.2.1",
     "ssl-root-cas": "^1.2.3",
-    "ultra_cart_rest_api_v2": "4.1.125"
+    "ultra_cart_rest_api_v2": "4.1.130"
   }
 }

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "ultracart/rest_api_v2_sdk_php": "4.1.129"
+        "ultracart/rest_api_v2_sdk_php": "4.1.130"
     },
     "config": {
         "discard-changes": true

--- a/php/order/getOrderCustomerActivity.php
+++ b/php/order/getOrderCustomerActivity.php
@@ -1,0 +1,47 @@
+<?php
+
+ini_set('display_errors', 1);
+
+use ultracart\v2\api\OrderApi;
+
+require_once '../vendor/autoload.php';
+require_once '../constants.php';
+
+/*
+    getOrderCustomerActivity returns the customer activity associated with the email address on an order.
+    This includes email engagement history, email list and segment membership, lifetime metrics and email
+    suppression status.
+
+    A customer profile is NOT required and is not consulted.  The activity is keyed off the email address
+    on the order, so this works for guest orders that have never had a customer profile established.  For
+    the page views captured during the session that placed the order, use getOrderPageViewHistory instead.
+
+    If the order has no valid email address, email and customer_activity both come back null.  That is a
+    successful response rather than an error - without an email there is no activity record to find.
+
+    Note: activity ts is a unix timestamp in milliseconds, not an ISO 8601 string like most dates in this API.
+
+    Possible Errors:
+    order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+
+ */
+
+
+$order_api = OrderApi::usingApiKey(Constants::API_KEY, false, false);
+
+
+$order_id = 'DEMO-0009104976';
+$response = $order_api->getOrderCustomerActivity($order_id);
+
+$customer_activity = $response->getCustomerActivity();
+
+echo '<html lang="en"><body><pre>';
+echo 'Customer activity for: ' . $response->getEmail() . "\n\n";
+
+if ($customer_activity === null) {
+    echo 'No customer activity found for this order.';
+} else {
+    var_dump($customer_activity->getActivities());
+}
+
+echo '</pre></body></html>';

--- a/python/order/get_order_customer_activity.py
+++ b/python/order/get_order_customer_activity.py
@@ -1,0 +1,41 @@
+from ultracart.apis import OrderApi
+from samples import api_client
+
+# get_order_customer_activity() returns the customer activity associated with the email address on an
+# order.  This includes email engagement history, email list and segment membership, lifetime metrics and
+# email suppression status.
+#
+# A customer profile is NOT required and is not consulted.  The activity is keyed off the email address on
+# the order, so this works for guest orders that have never had a customer profile established.  For the
+# page views captured during the session that placed the order, use get_order_page_view_history() instead.
+#
+# If the order has no valid email address, email and customer_activity both come back None.  That is a
+# successful response rather than an error - without an email there is no activity record to find.
+#
+# Note: activity.ts is a unix timestamp in milliseconds, not an ISO 8601 string like most dates in this API.
+#
+# Possible Errors:
+# order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+
+# Create Order API instance
+order_api = OrderApi(api_client())
+
+# Order ID to retrieve customer activity for
+order_id = "DEMO-0009104976"
+
+# Retrieve customer activity
+response = order_api.get_order_customer_activity(order_id)
+
+print("Customer activity for: {}".format(response.email))
+
+customer_activity = response.customer_activity
+
+if customer_activity is None:
+    print("No customer activity found for this order.")
+else:
+    print("Globally unsubscribed: {}".format(customer_activity.global_unsubscribed))
+    print("Spam complaint: {}".format(customer_activity.spam_complaint))
+
+    # Print the activity history
+    for activity in customer_activity.activities or []:
+        print(activity)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,1 +1,1 @@
-ultracart-rest-sdk==4.1.125
+ultracart-rest-sdk==4.1.130

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'rubocop', group: 'development'
-gem 'ultracart_api', '4.1.125'
+gem 'ultracart_api', '4.1.130'

--- a/ruby/order/get_order_customer_activity.rb
+++ b/ruby/order/get_order_customer_activity.rb
@@ -1,0 +1,40 @@
+require 'ultracart_api'
+require_relative '../constants'
+
+# getOrderCustomerActivity returns the customer activity associated with the email address on an order.
+# This includes email engagement history, email list and segment membership, lifetime metrics and email
+# suppression status.
+#
+# A customer profile is NOT required and is not consulted.  The activity is keyed off the email address on
+# the order, so this works for guest orders that have never had a customer profile established.  For the
+# page views captured during the session that placed the order, use get_order_page_view_history instead.
+#
+# If the order has no valid email address, email and customer_activity both come back nil.  That is a
+# successful response rather than an error - without an email there is no activity record to find.
+#
+# Note: activity.ts is a unix timestamp in milliseconds, not an ISO 8601 string like most dates in this API.
+#
+# Possible Errors:
+# order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+order_api = UltracartClient::OrderApi.new_using_api_key(Constants::API_KEY)
+
+order_id = 'DEMO-0009104976'
+
+begin
+  api_response = order_api.get_order_customer_activity(order_id)
+  customer_activity = api_response.customer_activity
+
+  puts "Customer activity for: #{api_response.email}"
+
+  if customer_activity.nil?
+    puts 'No customer activity found for this order.'
+  else
+    puts "Globally unsubscribed: #{customer_activity.global_unsubscribed}"
+    puts "Spam complaint: #{customer_activity.spam_complaint}"
+
+    # Using inspect instead of var_dump for Ruby-style object representation
+    puts customer_activity.activities.inspect
+  end
+rescue StandardError => e
+  puts "An error occurred: #{e.message}"
+end

--- a/typescript/order/GetOrderCustomerActivity.ts
+++ b/typescript/order/GetOrderCustomerActivity.ts
@@ -1,0 +1,55 @@
+import { orderApi } from '../api';
+import {
+    OrderCustomerActivityResponse,
+    CustomerActivity,
+    Activity
+} from 'ultracart_rest_api_v2_typescript';
+
+/**
+ * getOrderCustomerActivity returns the customer activity associated with the email address on an order.
+ * This includes email engagement history, email list and segment membership, lifetime metrics and email
+ * suppression status.
+ *
+ * A customer profile is NOT required and is not consulted.  The activity is keyed off the email address
+ * on the order, so this works for guest orders that have never had a customer profile established.  For
+ * the page views captured during the session that placed the order, use getOrderPageViewHistory instead.
+ *
+ * If the order has no valid email address, email and customer_activity both come back null.  That is a
+ * successful response rather than an error - without an email there is no activity record to find.
+ *
+ * Note: activity.ts is a unix timestamp in milliseconds, not an ISO 8601 string like most dates in this API.
+ *
+ * Possible Errors:
+ * order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+ */
+export async function execute(): Promise<void> {
+    const orderId = "DEMO-0009104976";
+
+    try {
+        const response: OrderCustomerActivityResponse = await orderApi.getOrderCustomerActivity({
+            orderId: orderId
+        });
+
+        console.log(`Customer activity for: ${response.email}`);
+
+        const customerActivity: CustomerActivity | undefined = response.customer_activity;
+
+        if (!customerActivity) {
+            console.log('No customer activity found for this order.');
+            return;
+        }
+
+        console.log(`Globally unsubscribed: ${customerActivity.global_unsubscribed}`);
+        console.log(`Spam complaint: ${customerActivity.spam_complaint}`);
+
+        const activities: Activity[] = customerActivity.activities || [];
+
+        for (const activity of activities) {
+            const timestamp = activity.ts ? new Date(activity.ts).toISOString() : 'unknown';
+            console.log(`${timestamp} - ${activity.type} - ${activity.action}`
+                + (activity.subject ? ` - ${activity.subject}` : ''));
+        }
+    } catch (error) {
+        console.error('Error fetching customer activity:', error);
+    }
+}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -7,7 +7,7 @@
     "@types/node": "^16.18.126",
     "luxon": "2.5.2",
     "typescript": "^4.9.5",
-    "ultracart_rest_api_v2_typescript": "4.1.125",
+    "ultracart_rest_api_v2_typescript": "4.1.130",
     "uuid": "^11.1.0"
   },
   "author": "UltraCart",


### PR DESCRIPTION
## What

Samples for the new order customer activity endpoint across all eight sample targets, plus an SDK version bump to **4.1.130** in every manifest.

`GET /rest/v2/order/orders/{order_id}/customer_activity` returns the ESP customer activity — email engagement history, email list/segment membership, lifetime metrics and email suppression status — for the email address on an order.

## Why

The endpoint exists so this data can be reached **without a customer profile**.

Activity is keyed by merchant + email, and the ESP customer is established at order placement for any order carrying a valid email. So the activity stream exists for guest orders that have never had *Establish customer profile* run against them. Until now the only route to it was the customer profile endpoints with `_expand=activity`, which return 404 before ever reaching the lookup when no profile exists — an API routing artifact, not a gap in the data.

This came out of a chargeback-evidence request: pulling the activity log previously required a human to click *Establish customer profile* in the back office first.

## Samples added

| Target | File |
|---|---|
| JavaScript | `javascript/order/getOrderCustomerActivity.js` |
| TypeScript | `typescript/order/GetOrderCustomerActivity.ts` |
| PHP | `php/order/getOrderCustomerActivity.php` |
| Python | `python/order/get_order_customer_activity.py` |
| Ruby | `ruby/order/get_order_customer_activity.rb` |
| C# | `csharp/order/GetOrderCustomerActivity.cs` |
| Java | `java/src/order/GetOrderCustomerActivity.java` |
| curl | `curl/order/getOrderCustomerActivity.curl` |

Each one documents the four things a caller will otherwise get wrong:

- no customer profile is required
- `getOrderPageViewHistory` covers the separate page-view side of "activity" (keyed off the order's `ucacid`, not the email)
- `ts` on an activity is **unix milliseconds**, not ISO 8601 like most dates in this API
- an order with no email returns a success response with null fields, not an error

## SDK bump

All eight manifests moved to 4.1.130: `javascript/package.json`, `typescript/package.json`, `php/composer.json`, `python/requirements.txt`, `ruby/Gemfile`, `csharp/packages.config` + `csharp/SDKSample.csproj`, `java/pom.xml`. The new `.cs` sample is registered in `SDKSample.csproj`.

## Heads up

**4.1.130 is published for JavaScript, TypeScript, Python, Ruby and PHP only.** NuGet and Maven Central are both still at 4.1.129, so the C# and Java samples will not build until those two publish. They are written against the same generator naming as the other five and should need no changes when the packages land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
