### PR TITLE
Fill in getOrderPageViewHistory and getOrderEmails samples

### DIFF
--- a/csharp/SDKSample.csproj
+++ b/csharp/SDKSample.csproj
@@ -349,6 +349,8 @@
     <Compile Include="order\GetOrderByToken.cs" />
     <Compile Include="order\GetOrderCustomerActivity.cs" />
     <Compile Include="order\GetOrderEdiDocuments.cs" />
+    <Compile Include="order\GetOrderEmails.cs" />
+    <Compile Include="order\GetOrderPageViewHistory.cs" />
     <Compile Include="order\GetOrders.cs" />
     <Compile Include="order\GetOrdersBatch.cs" />
     <Compile Include="order\GetOrdersByQuery.cs" />

--- a/csharp/order/GetOrderEmails.cs
+++ b/csharp/order/GetOrderEmails.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using com.ultracart.admin.v2.Api;
+using com.ultracart.admin.v2.Model;
+using Newtonsoft.Json;
+
+namespace SdkSample.order
+{
+    public class GetOrderEmails
+    {
+        /*
+            getOrderEmails returns the delivery records for every email UltraCart sent regarding an order,
+            oldest first.  Each record carries the subject and send time plus delivery, open, click and
+            bounce status, which makes this useful evidence that a customer was notified about their
+            order.
+
+            A customer profile is NOT required.  These records are tied to the order id itself.
+
+            An order with no email history, or one whose emails were all suppressed, comes back with an
+            empty Emails list.  That is a successful response rather than an error.
+
+            The Internal flag marks messages sent to merchant staff rather than to the customer.  Filter
+            those out if you only want what the customer actually received.
+
+            Possible Errors:
+            order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+         */
+        public static void Execute()
+        {
+            OrderApi orderApi = new OrderApi(Constants.ApiKey);
+
+            string orderId = "DEMO-0009104976";
+            OrderEmailsResponse response = orderApi.GetOrderEmails(orderId);
+            List<OrderEmail> emails = response.Emails;
+
+            if (emails == null || emails.Count == 0)
+            {
+                Console.WriteLine("No emails were sent for this order.");
+                return;
+            }
+
+            foreach (OrderEmail email in emails)
+            {
+                Console.WriteLine(JsonConvert.SerializeObject(email,
+                    new JsonSerializerSettings { Formatting = Formatting.Indented }));
+            }
+
+        }
+    }
+}

--- a/csharp/order/GetOrderPageViewHistory.cs
+++ b/csharp/order/GetOrderPageViewHistory.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using com.ultracart.admin.v2.Api;
+using com.ultracart.admin.v2.Model;
+using Newtonsoft.Json;
+
+namespace SdkSample.order
+{
+    public class GetOrderPageViewHistory
+    {
+        /*
+            getOrderPageViewHistory returns the page views captured during the session that placed an
+            order, along with the referrer that started that session.
+
+            A customer profile is NOT required.  These page views are keyed off an analytics client id
+            stored on the order itself, so this works for guest orders.  For the email engagement side of
+            customer activity, use GetOrderCustomerActivity instead.
+
+            An order placed outside the storefront, such as a phone order or an order imported from a
+            channel partner, will have no analytics session attached.  In that case PageViews comes back
+            empty.  That is a successful response rather than an error.
+
+            Note: ViewDts is an ISO 8601 string here.  Be aware that the Ts field on
+            GetOrderCustomerActivity is unix milliseconds instead, so do not assume the two methods format
+            dates the same way.
+
+            Possible Errors:
+            order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+         */
+        public static void Execute()
+        {
+            OrderApi orderApi = new OrderApi(Constants.ApiKey);
+
+            string orderId = "DEMO-0009104976";
+            OrderPageViewHistoryResponse response = orderApi.GetOrderPageViewHistory(orderId);
+
+            Console.WriteLine("Session referrer: " + (response.Referrer ?? "(none captured)"));
+
+            List<OrderPageView> pageViews = response.PageViews;
+
+            if (pageViews == null || pageViews.Count == 0)
+            {
+                Console.WriteLine("No page views were captured for this order.");
+                return;
+            }
+
+            foreach (OrderPageView pageView in pageViews)
+            {
+                Console.WriteLine(JsonConvert.SerializeObject(pageView,
+                    new JsonSerializerSettings { Formatting = Formatting.Indented }));
+            }
+
+        }
+    }
+}

--- a/curl/order/getOrderEmails.curl
+++ b/curl/order/getOrderEmails.curl
@@ -1,0 +1,107 @@
+**Request \[[Create API Key](https://ultracart.atlassian.net/wiki/spaces/ucdoc/pages/38688545/API+Simple+Key)\]**
+```bash
+curl -X GET "https://secure.ultracart.com/rest/v2/order/orders/DEMO-0009104976/emails" \
+  -H "Accept: application/json" \
+  -H "X-UltraCart-Api-Version: 2017-03-01" \
+  -H "x-ultracart-simple-key: 976892e9c788c00199a693ade98001004b139b72bb4d470199a693ade9800100"
+```
+
+Returns the delivery records for every email UltraCart sent regarding the order, oldest first.  Each
+record carries the subject and send time plus delivery, open, click and bounce status.  A customer profile
+is not required, so this works for guest orders.
+
+The `internal` flag marks messages sent to merchant staff rather than to the customer.  Filter those out
+if you only want what the customer actually received.
+
+**Response Headers**
+```html
+Status: 200 OK
+X-UltraCart-Request-Id: 7B2E4C91FA6D330199BFD48B4880011
+Content-Type: application/json; charset=UTF-8
+Transfer-Encoding: chunked
+Date: Tue, 07 Oct 2025 18:15:29 GMT
+```
+
+**Response Body**
+```json
+{
+    "emails": [
+        {
+            "email": "support@ultracart.com",
+            "subject": "Order Confirmation DEMO-0009104976",
+            "message_id": "0100019bfd48b488-3c1a7e02-9d44-4f61-8b23-5e9c7a1d0f42-000000",
+            "send_dts": "2025-10-06T14:04:22-04:00",
+            "delivered": true,
+            "delivery_dts": "2025-10-06T14:04:25-04:00",
+            "opened": true,
+            "opened_dts": "2025-10-06T15:12:47-04:00",
+            "clicked": false,
+            "skipped": false,
+            "internal": false,
+            "smtp_response": "250 2.0.0 OK",
+            "reporting_mta": "a8-51.smtp-out.amazonses.com"
+        },
+        {
+            "email": "support@ultracart.com",
+            "subject": "Your order has shipped",
+            "message_id": "0100019bfd48b488-7f2b9c41-6e08-4a92-b715-2d3f8e6c9a07-000000",
+            "send_dts": "2025-10-07T09:31:04-04:00",
+            "delivered": true,
+            "delivery_dts": "2025-10-07T09:31:07-04:00",
+            "opened": true,
+            "opened_dts": "2025-10-07T10:02:18-04:00",
+            "clicked": true,
+            "clicked_dts": "2025-10-07T10:02:44-04:00",
+            "skipped": false,
+            "internal": false,
+            "smtp_response": "250 2.0.0 OK",
+            "reporting_mta": "a8-51.smtp-out.amazonses.com"
+        }
+    ],
+    "success": true,
+    "metadata": {}
+}
+```
+
+**Response Body \(bounced email\)**
+```json
+{
+    "emails": [
+        {
+            "email": "bad-address@example.com",
+            "subject": "Order Confirmation DEMO-0009104976",
+            "send_dts": "2025-10-06T14:04:22-04:00",
+            "delivered": false,
+            "bounce_dts": "2025-10-06T14:04:31-04:00",
+            "bounce_type": "Permanent",
+            "bounce_sub_type": "NoEmail",
+            "bounce_diagnostic_code": "smtp; 550 5.1.1 user unknown",
+            "internal": false
+        }
+    ],
+    "success": true,
+    "metadata": {}
+}
+```
+
+**Error Response Headers**
+```html
+Status: 400 Bad Request
+X-UltraCart-Request-Id: E93FDA26B70CC10199BFCAF7C780011
+UC-REST-ERROR: Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log.
+Content-Type: application/json; charset=UTF-8
+Connection: close
+Transfer-Encoding: chunked
+Date: Tue, 07 Oct 2025 18:01:15 GMT
+```
+
+**Error Response Body**
+```json
+{
+    "error": {
+        "developer_message": "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log.",
+        "user_message": "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+    },
+    "metadata": {}
+}
+```

--- a/curl/order/getOrderPageViewHistory.curl
+++ b/curl/order/getOrderPageViewHistory.curl
@@ -1,0 +1,92 @@
+**Request \[[Create API Key](https://ultracart.atlassian.net/wiki/spaces/ucdoc/pages/38688545/API+Simple+Key)\]**
+```bash
+curl -X GET "https://secure.ultracart.com/rest/v2/order/orders/DEMO-0009104976/page_view_history" \
+  -H "Accept: application/json" \
+  -H "X-UltraCart-Api-Version: 2017-03-01" \
+  -H "x-ultracart-simple-key: 976892e9c788c00199a693ade98001004b139b72bb4d470199a693ade9800100"
+```
+
+Returns the page views captured during the session that placed the order, along with the referrer that
+started that session.  A customer profile is not required, so this works for guest orders.  For the email
+engagement side of customer activity, see getOrderCustomerActivity.
+
+Note that `view_dts` is an ISO 8601 string here, while `ts` on getOrderCustomerActivity is unix
+milliseconds.  The two methods do not format dates the same way.
+
+**Response Headers**
+```html
+Status: 200 OK
+X-UltraCart-Request-Id: C41A9E75B3D0810199BFD48B4880011
+Content-Type: application/json; charset=UTF-8
+Transfer-Encoding: chunked
+Date: Tue, 07 Oct 2025 18:11:47 GMT
+```
+
+**Response Body**
+```json
+{
+    "page_views": [
+        {
+            "url": "https://www.example.com/",
+            "time_on_page": 24,
+            "view_dts": "2025-10-06T14:02:11-04:00",
+            "params": [
+                {
+                    "name": "utm_source",
+                    "value": "newsletter"
+                }
+            ]
+        },
+        {
+            "url": "https://www.example.com/products/doggie-bones",
+            "time_on_page": 96,
+            "view_dts": "2025-10-06T14:02:35-04:00",
+            "meta_data": [
+                {
+                    "name": "item_id",
+                    "value": "BONE"
+                }
+            ]
+        },
+        {
+            "url": "https://secure.ultracart.com/checkout/",
+            "time_on_page": 143,
+            "view_dts": "2025-10-06T14:04:11-04:00"
+        }
+    ],
+    "referrer": "https://www.google.com/",
+    "success": true,
+    "metadata": {}
+}
+```
+
+**Response Body \(order has no analytics session, such as a phone order\)**
+```json
+{
+    "page_views": [],
+    "success": true,
+    "metadata": {}
+}
+```
+
+**Error Response Headers**
+```html
+Status: 400 Bad Request
+X-UltraCart-Request-Id: D82BEA07C51FB60199BFCAF7C780011
+UC-REST-ERROR: Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log.
+Content-Type: application/json; charset=UTF-8
+Connection: close
+Transfer-Encoding: chunked
+Date: Tue, 07 Oct 2025 17:58:02 GMT
+```
+
+**Error Response Body**
+```json
+{
+    "error": {
+        "developer_message": "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log.",
+        "user_message": "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+    },
+    "metadata": {}
+}
+```

--- a/java/src/order/GetOrderEmails.java
+++ b/java/src/order/GetOrderEmails.java
@@ -1,0 +1,44 @@
+package order;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.ultracart.admin.v2.OrderApi;
+import com.ultracart.admin.v2.models.*;
+import com.ultracart.admin.v2.util.ApiException;
+import java.util.List;
+
+public class GetOrderEmails {
+   /*
+       getOrderEmails returns the delivery records for every email UltraCart sent regarding an order,
+       oldest first.  Each record carries the subject and send time plus delivery, open, click and bounce
+       status, which makes this useful evidence that a customer was notified about their order.
+
+       A customer profile is NOT required.  These records are tied to the order id itself.
+
+       An order with no email history, or one whose emails were all suppressed, comes back with an empty
+       list.  That is a successful response rather than an error.
+
+       The getInternal() flag marks messages sent to merchant staff rather than to the customer.  Filter
+       those out if you only want what the customer actually received.
+
+       Possible Errors:
+       order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+    */
+   public void execute() throws ApiException {
+       OrderApi orderApi = new OrderApi(common.Constants.API_KEY);
+
+       String orderId = "DEMO-0009104976";
+       OrderEmailsResponse response = orderApi.getOrderEmails(orderId);
+       List<OrderEmail> emails = response.getEmails();
+
+       if (emails == null || emails.isEmpty()) {
+           System.out.println("No emails were sent for this order.");
+           return;
+       }
+
+       Gson gson = new GsonBuilder().setPrettyPrinting().create();
+       for (OrderEmail email : emails) {
+           System.out.println(gson.toJson(email));
+       }
+   }
+}

--- a/java/src/order/GetOrderPageViewHistory.java
+++ b/java/src/order/GetOrderPageViewHistory.java
@@ -1,0 +1,50 @@
+package order;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.ultracart.admin.v2.OrderApi;
+import com.ultracart.admin.v2.models.*;
+import com.ultracart.admin.v2.util.ApiException;
+import java.util.List;
+
+public class GetOrderPageViewHistory {
+   /*
+       getOrderPageViewHistory returns the page views captured during the session that placed an order,
+       along with the referrer that started that session.
+
+       A customer profile is NOT required.  These page views are keyed off an analytics client id stored
+       on the order itself, so this works for guest orders.  For the email engagement side of customer
+       activity, use getOrderCustomerActivity instead.
+
+       An order placed outside the storefront, such as a phone order or an order imported from a channel
+       partner, will have no analytics session attached.  In that case getPageViews() comes back empty.
+       That is a successful response rather than an error.
+
+       Note: getViewDts() is an ISO 8601 string here.  Be aware that getTs() on getOrderCustomerActivity
+       is unix milliseconds instead, so do not assume the two methods format dates the same way.
+
+       Possible Errors:
+       order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+    */
+   public void execute() throws ApiException {
+       OrderApi orderApi = new OrderApi(common.Constants.API_KEY);
+
+       String orderId = "DEMO-0009104976";
+       OrderPageViewHistoryResponse response = orderApi.getOrderPageViewHistory(orderId);
+
+       String referrer = response.getReferrer();
+       System.out.println("Session referrer: " + (referrer == null ? "(none captured)" : referrer));
+
+       List<OrderPageView> pageViews = response.getPageViews();
+
+       if (pageViews == null || pageViews.isEmpty()) {
+           System.out.println("No page views were captured for this order.");
+           return;
+       }
+
+       Gson gson = new GsonBuilder().setPrettyPrinting().create();
+       for (OrderPageView pageView : pageViews) {
+           System.out.println(gson.toJson(pageView));
+       }
+   }
+}

--- a/javascript/order/getOrderEmails.js
+++ b/javascript/order/getOrderEmails.js
@@ -1,0 +1,57 @@
+import {orderApi} from '../api.js';
+
+/**
+ * getOrderEmails returns the delivery records for every email UltraCart sent regarding an order,
+ * oldest first.  Each record carries the subject and send time plus delivery, open, click and bounce
+ * status, which makes this useful evidence that a customer was notified about their order.
+ *
+ * A customer profile is NOT required.  These records are tied to the order id itself.
+ *
+ * An order with no email history, or one whose emails were all suppressed, comes back with an empty
+ * emails array.  That is a successful response rather than an error.
+ *
+ * The `internal` flag marks messages sent to merchant staff rather than to the customer.  Filter those
+ * out if you only want what the customer actually received.
+ *
+ * Possible Errors:
+ * order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+ */
+export async function execute() {
+    const orderId = "DEMO-0009104976";
+
+    try {
+        const response = await new Promise((resolve, reject) => {
+            orderApi.getOrderEmails(
+                orderId
+                , function (error, data, response) {
+                    if (error) {
+                        reject(error);
+                    } else {
+                        resolve(data);
+                    }
+                });
+        });
+
+        const emails = response.emails || [];
+
+        if (emails.length === 0) {
+            console.log('No emails were sent for this order.');
+            return;
+        }
+
+        for (const email of emails) {
+            console.log(email.send_dts + ' - ' + email.email + ' - ' + email.subject);
+
+            const status = [];
+            if (email.delivered) status.push('delivered ' + email.delivery_dts);
+            if (email.opened) status.push('opened ' + email.opened_dts);
+            if (email.clicked) status.push('clicked ' + email.clicked_dts);
+            if (email.skipped) status.push('skipped: ' + email.skip_reason);
+            if (email.bounce_type) status.push('bounced ' + email.bounce_type + '/' + email.bounce_sub_type);
+
+            console.log('    ' + (status.length ? status.join(', ') : 'no delivery events recorded'));
+        }
+    } catch (error) {
+        console.error('Error fetching order emails:', error);
+    }
+}

--- a/javascript/order/getOrderPageViewHistory.js
+++ b/javascript/order/getOrderPageViewHistory.js
@@ -1,0 +1,61 @@
+import {orderApi} from '../api.js';
+
+/**
+ * getOrderPageViewHistory returns the page views captured during the session that placed an order,
+ * along with the referrer that started that session.
+ *
+ * A customer profile is NOT required.  These page views are keyed off an analytics client id stored on
+ * the order itself, so this works for guest orders.  For the email engagement side of customer activity,
+ * use getOrderCustomerActivity instead.
+ *
+ * An order placed outside the storefront, such as a phone order or an order imported from a channel
+ * partner, will have no analytics session attached.  In that case page_views comes back empty.  That is a
+ * successful response rather than an error.
+ *
+ * Note: view_dts is an ISO 8601 string here.  Be aware that the ts field on getOrderCustomerActivity is
+ * unix milliseconds instead, so do not assume the two methods format dates the same way.
+ *
+ * Possible Errors:
+ * order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+ */
+export async function execute() {
+    const orderId = "DEMO-0009104976";
+
+    try {
+        const response = await new Promise((resolve, reject) => {
+            orderApi.getOrderPageViewHistory(
+                orderId
+                , function (error, data, response) {
+                    if (error) {
+                        reject(error);
+                    } else {
+                        resolve(data);
+                    }
+                });
+        });
+
+        console.log('Session referrer: ' + (response.referrer || '(none captured)'));
+
+        const pageViews = response.page_views || [];
+
+        if (pageViews.length === 0) {
+            console.log('No page views were captured for this order.');
+            return;
+        }
+
+        for (const pageView of pageViews) {
+            console.log(pageView.view_dts + ' - ' + pageView.url
+                + (pageView.time_on_page ? ' (' + pageView.time_on_page + 's on page)' : ''));
+
+            for (const param of pageView.params || []) {
+                console.log('    param ' + param.name + ' = ' + param.value);
+            }
+
+            for (const meta of pageView.meta_data || []) {
+                console.log('    meta  ' + meta.name + ' = ' + meta.value);
+            }
+        }
+    } catch (error) {
+        console.error('Error fetching page view history:', error);
+    }
+}

--- a/php/order/getOrderEmails.php
+++ b/php/order/getOrderEmails.php
@@ -1,0 +1,48 @@
+<?php
+
+ini_set('display_errors', 1);
+
+use ultracart\v2\api\OrderApi;
+
+require_once '../vendor/autoload.php';
+require_once '../constants.php';
+
+/*
+    getOrderEmails returns the delivery records for every email UltraCart sent regarding an order, oldest
+    first.  Each record carries the subject and send time plus delivery, open, click and bounce status,
+    which makes this useful evidence that a customer was notified about their order.
+
+    A customer profile is NOT required.  These records are tied to the order id itself.
+
+    An order with no email history, or one whose emails were all suppressed, comes back with an empty
+    emails array.  That is a successful response rather than an error.
+
+    The internal flag marks messages sent to merchant staff rather than to the customer.  Filter those out
+    if you only want what the customer actually received.
+
+    Possible Errors:
+    order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+
+ */
+
+
+$order_api = OrderApi::usingApiKey(Constants::API_KEY, false, false);
+
+
+$order_id = 'DEMO-0009104976';
+$emails = $order_api->getOrderEmails($order_id)->getEmails();
+
+echo '<html lang="en"><body><pre>';
+
+if (empty($emails)) {
+    echo 'No emails were sent for this order.';
+} else {
+    foreach ($emails as $email) {
+        echo $email->getSendDts() . ' - ' . $email->getEmail() . ' - ' . $email->getSubject() . "\n";
+    }
+
+    echo "\n";
+    var_dump($emails);
+}
+
+echo '</pre></body></html>';

--- a/php/order/getOrderPageViewHistory.php
+++ b/php/order/getOrderPageViewHistory.php
@@ -1,0 +1,53 @@
+<?php
+
+ini_set('display_errors', 1);
+
+use ultracart\v2\api\OrderApi;
+
+require_once '../vendor/autoload.php';
+require_once '../constants.php';
+
+/*
+    getOrderPageViewHistory returns the page views captured during the session that placed an order,
+    along with the referrer that started that session.
+
+    A customer profile is NOT required.  These page views are keyed off an analytics client id stored on
+    the order itself, so this works for guest orders.  For the email engagement side of customer activity,
+    use getOrderCustomerActivity instead.
+
+    An order placed outside the storefront, such as a phone order or an order imported from a channel
+    partner, will have no analytics session attached.  In that case page_views comes back empty.  That is
+    a successful response rather than an error.
+
+    Note: view_dts is an ISO 8601 string here.  Be aware that the ts field on getOrderCustomerActivity is
+    unix milliseconds instead, so do not assume the two methods format dates the same way.
+
+    Possible Errors:
+    order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+
+ */
+
+
+$order_api = OrderApi::usingApiKey(Constants::API_KEY, false, false);
+
+
+$order_id = 'DEMO-0009104976';
+$response = $order_api->getOrderPageViewHistory($order_id);
+
+$page_views = $response->getPageViews();
+
+echo '<html lang="en"><body><pre>';
+echo 'Session referrer: ' . ($response->getReferrer() ?: '(none captured)') . "\n\n";
+
+if (empty($page_views)) {
+    echo 'No page views were captured for this order.';
+} else {
+    foreach ($page_views as $page_view) {
+        echo $page_view->getViewDts() . ' - ' . $page_view->getUrl() . "\n";
+    }
+
+    echo "\n";
+    var_dump($page_views);
+}
+
+echo '</pre></body></html>';

--- a/python/order/get_order_emails.py
+++ b/python/order/get_order_emails.py
@@ -1,0 +1,46 @@
+from ultracart.apis import OrderApi
+from samples import api_client
+
+# get_order_emails() returns the delivery records for every email UltraCart sent regarding an order,
+# oldest first.  Each record carries the subject and send time plus delivery, open, click and bounce
+# status, which makes this useful evidence that a customer was notified about their order.
+#
+# A customer profile is NOT required.  These records are tied to the order id itself.
+#
+# An order with no email history, or one whose emails were all suppressed, comes back with an empty emails
+# list.  That is a successful response rather than an error.
+#
+# The internal flag marks messages sent to merchant staff rather than to the customer.  Filter those out
+# if you only want what the customer actually received.
+#
+# Possible Errors:
+# order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+
+# Create Order API instance
+order_api = OrderApi(api_client())
+
+# Order ID to retrieve email delivery information for
+order_id = "DEMO-0009104976"
+
+# Retrieve the emails sent for this order
+emails = order_api.get_order_emails(order_id).emails or []
+
+if not emails:
+    print("No emails were sent for this order.")
+else:
+    for email in emails:
+        print("{} - {} - {}".format(email.send_dts, email.email, email.subject))
+
+        status = []
+        if email.delivered:
+            status.append("delivered {}".format(email.delivery_dts))
+        if email.opened:
+            status.append("opened {}".format(email.opened_dts))
+        if email.clicked:
+            status.append("clicked {}".format(email.clicked_dts))
+        if email.skipped:
+            status.append("skipped: {}".format(email.skip_reason))
+        if email.bounce_type:
+            status.append("bounced {}/{}".format(email.bounce_type, email.bounce_sub_type))
+
+        print("    {}".format(", ".join(status) if status else "no delivery events recorded"))

--- a/python/order/get_order_page_view_history.py
+++ b/python/order/get_order_page_view_history.py
@@ -1,0 +1,45 @@
+from ultracart.apis import OrderApi
+from samples import api_client
+
+# get_order_page_view_history() returns the page views captured during the session that placed an order,
+# along with the referrer that started that session.
+#
+# A customer profile is NOT required.  These page views are keyed off an analytics client id stored on the
+# order itself, so this works for guest orders.  For the email engagement side of customer activity, use
+# get_order_customer_activity() instead.
+#
+# An order placed outside the storefront, such as a phone order or an order imported from a channel
+# partner, will have no analytics session attached.  In that case page_views comes back empty.  That is a
+# successful response rather than an error.
+#
+# Note: view_dts is an ISO 8601 string here.  Be aware that the ts field on get_order_customer_activity()
+# is unix milliseconds instead, so do not assume the two methods format dates the same way.
+#
+# Possible Errors:
+# order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+
+# Create Order API instance
+order_api = OrderApi(api_client())
+
+# Order ID to retrieve page view history for
+order_id = "DEMO-0009104976"
+
+# Retrieve page view history
+response = order_api.get_order_page_view_history(order_id)
+
+print("Session referrer: {}".format(response.referrer or "(none captured)"))
+
+page_views = response.page_views or []
+
+if not page_views:
+    print("No page views were captured for this order.")
+else:
+    for page_view in page_views:
+        time_on_page = " ({}s on page)".format(page_view.time_on_page) if page_view.time_on_page else ""
+        print("{} - {}{}".format(page_view.view_dts, page_view.url, time_on_page))
+
+        for param in page_view.params or []:
+            print("    param {} = {}".format(param.name, param.value))
+
+        for meta in page_view.meta_data or []:
+            print("    meta  {} = {}".format(meta.name, meta.value))

--- a/ruby/order/get_order_emails.rb
+++ b/ruby/order/get_order_emails.rb
@@ -1,0 +1,44 @@
+require 'ultracart_api'
+require_relative '../constants'
+
+# getOrderEmails returns the delivery records for every email UltraCart sent regarding an order, oldest
+# first.  Each record carries the subject and send time plus delivery, open, click and bounce status,
+# which makes this useful evidence that a customer was notified about their order.
+#
+# A customer profile is NOT required.  These records are tied to the order id itself.
+#
+# An order with no email history, or one whose emails were all suppressed, comes back with an empty emails
+# array.  That is a successful response rather than an error.
+#
+# The internal flag marks messages sent to merchant staff rather than to the customer.  Filter those out
+# if you only want what the customer actually received.
+#
+# Possible Errors:
+# order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+order_api = UltracartClient::OrderApi.new_using_api_key(Constants::API_KEY)
+
+order_id = 'DEMO-0009104976'
+
+begin
+  api_response = order_api.get_order_emails(order_id)
+  emails = api_response.emails || []
+
+  if emails.empty?
+    puts 'No emails were sent for this order.'
+  else
+    emails.each do |email|
+      puts "#{email.send_dts} - #{email.email} - #{email.subject}"
+
+      status = []
+      status << "delivered #{email.delivery_dts}" if email.delivered
+      status << "opened #{email.opened_dts}" if email.opened
+      status << "clicked #{email.clicked_dts}" if email.clicked
+      status << "skipped: #{email.skip_reason}" if email.skipped
+      status << "bounced #{email.bounce_type}/#{email.bounce_sub_type}" if email.bounce_type
+
+      puts "    #{status.empty? ? 'no delivery events recorded' : status.join(', ')}"
+    end
+  end
+rescue StandardError => e
+  puts "An error occurred: #{e.message}"
+end

--- a/ruby/order/get_order_page_view_history.rb
+++ b/ruby/order/get_order_page_view_history.rb
@@ -1,0 +1,43 @@
+require 'ultracart_api'
+require_relative '../constants'
+
+# getOrderPageViewHistory returns the page views captured during the session that placed an order, along
+# with the referrer that started that session.
+#
+# A customer profile is NOT required.  These page views are keyed off an analytics client id stored on the
+# order itself, so this works for guest orders.  For the email engagement side of customer activity, use
+# get_order_customer_activity instead.
+#
+# An order placed outside the storefront, such as a phone order or an order imported from a channel
+# partner, will have no analytics session attached.  In that case page_views comes back empty.  That is a
+# successful response rather than an error.
+#
+# Note: view_dts is an ISO 8601 string here.  Be aware that the ts field on get_order_customer_activity is
+# unix milliseconds instead, so do not assume the two methods format dates the same way.
+#
+# Possible Errors:
+# order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+order_api = UltracartClient::OrderApi.new_using_api_key(Constants::API_KEY)
+
+order_id = 'DEMO-0009104976'
+
+begin
+  api_response = order_api.get_order_page_view_history(order_id)
+  page_views = api_response.page_views || []
+
+  puts "Session referrer: #{api_response.referrer || '(none captured)'}"
+
+  if page_views.empty?
+    puts 'No page views were captured for this order.'
+  else
+    page_views.each do |page_view|
+      time_on_page = page_view.time_on_page ? " (#{page_view.time_on_page}s on page)" : ''
+      puts "#{page_view.view_dts} - #{page_view.url}#{time_on_page}"
+    end
+
+    # Using inspect instead of var_dump for Ruby-style object representation
+    puts page_views.inspect
+  end
+rescue StandardError => e
+  puts "An error occurred: #{e.message}"
+end

--- a/typescript/order/GetOrderEmails.ts
+++ b/typescript/order/GetOrderEmails.ts
@@ -1,0 +1,53 @@
+import { orderApi } from '../api';
+import {
+    OrderEmailsResponse,
+    OrderEmail
+} from 'ultracart_rest_api_v2_typescript';
+
+/**
+ * getOrderEmails returns the delivery records for every email UltraCart sent regarding an order,
+ * oldest first.  Each record carries the subject and send time plus delivery, open, click and bounce
+ * status, which makes this useful evidence that a customer was notified about their order.
+ *
+ * A customer profile is NOT required.  These records are tied to the order id itself.
+ *
+ * An order with no email history, or one whose emails were all suppressed, comes back with an empty
+ * emails array.  That is a successful response rather than an error.
+ *
+ * The `internal` flag marks messages sent to merchant staff rather than to the customer.  Filter those
+ * out if you only want what the customer actually received.
+ *
+ * Possible Errors:
+ * order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+ */
+export async function execute(): Promise<void> {
+    const orderId = "DEMO-0009104976";
+
+    try {
+        const response: OrderEmailsResponse = await orderApi.getOrderEmails({
+            orderId: orderId
+        });
+
+        const emails: OrderEmail[] = response.emails || [];
+
+        if (emails.length === 0) {
+            console.log('No emails were sent for this order.');
+            return;
+        }
+
+        for (const email of emails) {
+            console.log(`${email.send_dts} - ${email.email} - ${email.subject}`);
+
+            const status: string[] = [];
+            if (email.delivered) status.push(`delivered ${email.delivery_dts}`);
+            if (email.opened) status.push(`opened ${email.opened_dts}`);
+            if (email.clicked) status.push(`clicked ${email.clicked_dts}`);
+            if (email.skipped) status.push(`skipped: ${email.skip_reason}`);
+            if (email.bounce_type) status.push(`bounced ${email.bounce_type}/${email.bounce_sub_type}`);
+
+            console.log(`    ${status.length ? status.join(', ') : 'no delivery events recorded'}`);
+        }
+    } catch (error) {
+        console.error('Error fetching order emails:', error);
+    }
+}

--- a/typescript/order/GetOrderPageViewHistory.ts
+++ b/typescript/order/GetOrderPageViewHistory.ts
@@ -1,0 +1,57 @@
+import { orderApi } from '../api';
+import {
+    OrderPageViewHistoryResponse,
+    OrderPageView
+} from 'ultracart_rest_api_v2_typescript';
+
+/**
+ * getOrderPageViewHistory returns the page views captured during the session that placed an order,
+ * along with the referrer that started that session.
+ *
+ * A customer profile is NOT required.  These page views are keyed off an analytics client id stored on
+ * the order itself, so this works for guest orders.  For the email engagement side of customer activity,
+ * use getOrderCustomerActivity instead.
+ *
+ * An order placed outside the storefront, such as a phone order or an order imported from a channel
+ * partner, will have no analytics session attached.  In that case page_views comes back empty.  That is a
+ * successful response rather than an error.
+ *
+ * Note: view_dts is an ISO 8601 string here.  Be aware that the ts field on getOrderCustomerActivity is
+ * unix milliseconds instead, so do not assume the two methods format dates the same way.
+ *
+ * Possible Errors:
+ * order_id does not start with the merchant id -> "Path parameter 'order_id' does not start with the merchant id.  Check your parameter value and call log."
+ */
+export async function execute(): Promise<void> {
+    const orderId = "DEMO-0009104976";
+
+    try {
+        const response: OrderPageViewHistoryResponse = await orderApi.getOrderPageViewHistory({
+            orderId: orderId
+        });
+
+        console.log(`Session referrer: ${response.referrer || '(none captured)'}`);
+
+        const pageViews: OrderPageView[] = response.page_views || [];
+
+        if (pageViews.length === 0) {
+            console.log('No page views were captured for this order.');
+            return;
+        }
+
+        for (const pageView of pageViews) {
+            const timeOnPage = pageView.time_on_page ? ` (${pageView.time_on_page}s on page)` : '';
+            console.log(`${pageView.view_dts} - ${pageView.url}${timeOnPage}`);
+
+            for (const param of pageView.params || []) {
+                console.log(`    param ${param.name} = ${param.value}`);
+            }
+
+            for (const meta of pageView.meta_data || []) {
+                console.log(`    meta  ${meta.name} = ${meta.value}`);
+            }
+        }
+    } catch (error) {
+        console.error('Error fetching page view history:', error);
+    }
+}


### PR DESCRIPTION
## What

Fills in the `getOrderPageViewHistory` and `getOrderEmails` samples across all eight targets. Both sets have existed as **empty 0-byte placeholder files since July**, so anyone who found them got nothing.

16 files written, 907 lines, no deletions.

## Why now

These pair with the `getOrderCustomerActivity` samples added in #16. Together the three cover what a merchant needs to assemble chargeback evidence for a single order:

| Endpoint | What it proves | Status |
|---|---|---|
| `page_view_history` | what the customer browsed before ordering | **live today** |
| `emails` | that we notified them, and that they opened/clicked | **live today** |
| `customer_activity` | email engagement, list membership, suppression | pending release |

The first two are already deployed. A merchant chasing this today can use them immediately, which is exactly why the empty placeholders were worth fixing before pointing anyone at them.

None of the three requires a customer profile, so all work on guest orders.

## Samples added

| Target | Page views | Emails |
|---|---|---|
| JavaScript | `javascript/order/getOrderPageViewHistory.js` | `javascript/order/getOrderEmails.js` |
| TypeScript | `typescript/order/GetOrderPageViewHistory.ts` | `typescript/order/GetOrderEmails.ts` |
| PHP | `php/order/getOrderPageViewHistory.php` | `php/order/getOrderEmails.php` |
| Python | `python/order/get_order_page_view_history.py` | `python/order/get_order_emails.py` |
| Ruby | `ruby/order/get_order_page_view_history.rb` | `ruby/order/get_order_emails.rb` |
| C# | `csharp/order/GetOrderPageViewHistory.cs` | `csharp/order/GetOrderEmails.cs` |
| Java | `java/src/order/GetOrderPageViewHistory.java` | `java/src/order/GetOrderEmails.java` |
| curl | `curl/order/getOrderPageViewHistory.curl` | `curl/order/getOrderEmails.curl` |

## Traps the samples call out

- **Neither method needs a customer profile.** Worth stating explicitly, since the customer profile endpoints are the usual route to anything activity-shaped.
- **Date formats differ between methods.** `view_dts` on a page view is ISO 8601; `ts` on a customer activity entry is unix milliseconds. Assuming they match produces 1970 dates.
- **An order with no analytics session returns an empty list, not an error.** Phone orders and channel partner imports land here.
- **The `internal` flag on an email** marks staff mail rather than customer mail. Filter it out if you only want what the customer received.

The curl samples show a bounced-email response and an empty page-view response alongside the happy path, since those are the shapes people hit in practice.

## Also

Registers `GetOrderPageViewHistory.cs` and `GetOrderEmails.cs` in `SDKSample.csproj`. Neither was ever added to the project, because both files were empty.

No SDK version change. Both methods already ship in every published SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
